### PR TITLE
Refactor simple options

### DIFF
--- a/src/main/java/org/httpserver/Constant.java
+++ b/src/main/java/org/httpserver/Constant.java
@@ -2,5 +2,4 @@ package org.httpserver;
 
 public class Constant {
     public static String CRLF = "\r\n";
-    public static String SP = " ";
 }

--- a/src/main/java/org/httpserver/Constant.java
+++ b/src/main/java/org/httpserver/Constant.java
@@ -1,0 +1,6 @@
+package org.httpserver;
+
+public class Constant {
+    public static String CRLF = "\r\n";
+    public static String SP = " ";
+}

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -26,10 +26,11 @@ public class HeadRequestHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -15,10 +16,8 @@ public class HeadRequestHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders() + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -27,11 +26,10 @@ public class HeadRequestHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -17,10 +18,8 @@ public class MethodNotAllowedHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders() + CRLF + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -28,11 +27,10 @@ public class MethodNotAllowedHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
         String statusCode = StatusCode.METHOD_NOT_ALLOWED.getStatusCode();
-        String statusText = String.valueOf(StatusCode.METHOD_NOT_ALLOWED).replace("_"," ");
+        String statusText = String.valueOf(StatusCode.METHOD_NOT_ALLOWED).replace("_", " ");
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -27,10 +27,11 @@ public class MethodNotAllowedHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.METHOD_NOT_ALLOWED.getStatusCode();
         String statusText = String.valueOf(StatusCode.METHOD_NOT_ALLOWED).replace("_", " ");
 
-        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/handler/OptionHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionHandler.java
@@ -1,0 +1,21 @@
+package org.httpserver.handler;
+
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
+import org.httpserver.server.HttpMethod;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class OptionHandler implements Handler{
+    @Override
+    public List<String> allowedHttpMethods() {
+        return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());
+    }
+
+
+    @Override
+    public Response handleResponse(Request request) {
+        return null;
+    }
+}

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -28,10 +28,11 @@ public class OptionsHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class OptionsHandler implements Handler{
+public class OptionsHandler implements Handler {
     @Override
     public List<String> allowedHttpMethods() {
         return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());
@@ -22,7 +22,7 @@ public class OptionsHandler implements Handler{
         String CRLF = "\r\n";
 
         String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders() + CRLF;
+        String responseHeaders = handleHeaders(request) + CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -37,11 +37,15 @@ public class OptionsHandler implements Handler{
         return request.getHttpVersion() + SP + statusCode + SP + statusText;
     }
 
-    private String handleHeaders() {
-        return "Allow: GET, HEAD, OPTIONS";
+    private String handleHeaders(Request request) {
+        if (Objects.equals(request.getRequestTarget(), "/method_options")) {
+            return "Allow: GET, HEAD, OPTIONS";
+        } else {
+            return "Allow: GET, HEAD, OPTIONS, PUT, POST";
+        }
     }
 
-    private String handleBody()  {
+    private String handleBody() {
         return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -22,7 +22,7 @@ public class OptionsHandler implements Handler {
         String CRLF = "\r\n";
 
         String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders(request) + CRLF;
+        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -8,7 +9,6 @@ import org.httpserver.server.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 public class OptionsHandler implements Handler {
     @Override
@@ -19,10 +19,8 @@ public class OptionsHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -30,11 +28,10 @@ public class OptionsHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -7,7 +7,7 @@ import org.httpserver.server.HttpMethod;
 import java.util.Arrays;
 import java.util.List;
 
-public class OptionHandler implements Handler{
+public class OptionsHandler implements Handler{
     @Override
     public List<String> allowedHttpMethods() {
         return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -2,10 +2,13 @@ package org.httpserver.handler;
 
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
+import org.httpserver.response.ResponseBuilder;
+import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class OptionsHandler implements Handler{
     @Override
@@ -16,6 +19,29 @@ public class OptionsHandler implements Handler{
 
     @Override
     public Response handleResponse(Request request) {
-        return null;
+        String CRLF = "\r\n";
+
+        String responseStatusLine = handleStatusLine(request) + CRLF;
+        String responseHeaders = handleHeaders() + CRLF;
+        String responseBody = handleBody();
+
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+    }
+
+    private String handleStatusLine(Request request) {
+        String SP = " ";
+        String statusCode = StatusCode.OK.getStatusCode();
+        String statusText = String.valueOf(StatusCode.OK);
+
+        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+    }
+
+    private String handleHeaders() {
+        return "Allow: GET, HEAD, OPTIONS";
+    }
+
+    private String handleBody()  {
+        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -18,10 +19,8 @@ public class OptionsHandlerTwo implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -29,11 +28,10 @@ public class OptionsHandlerTwo implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -9,18 +9,19 @@ import org.httpserver.server.HttpMethod;
 import java.util.Arrays;
 import java.util.List;
 
-public class OptionsHandlerTwo implements Handler{
+public class OptionsHandlerTwo implements Handler {
 
     @Override
     public List<String> allowedHttpMethods() {
         return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod(), HttpMethod.POST.getHttpMethod(), HttpMethod.PUT.getHttpMethod());
     }
+
     @Override
     public Response handleResponse(Request request) {
         String CRLF = "\r\n";
 
         String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders(request) + CRLF;
+        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -28,10 +28,11 @@ public class OptionsHandlerTwo implements Handler {
     }
 
     private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -8,15 +8,13 @@ import org.httpserver.server.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
-public class OptionsHandler implements Handler {
+public class OptionsHandlerTwo implements Handler{
+
     @Override
     public List<String> allowedHttpMethods() {
-        return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());
+        return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod(), HttpMethod.POST.getHttpMethod(), HttpMethod.PUT.getHttpMethod());
     }
-
-
     @Override
     public Response handleResponse(Request request) {
         String CRLF = "\r\n";
@@ -38,7 +36,7 @@ public class OptionsHandler implements Handler {
     }
 
     private String handleHeaders(Request request) {
-        return "Allow: GET, HEAD, OPTIONS";
+        return "Allow: GET, HEAD, OPTIONS, PUT, POST";
     }
 
     private String handleBody() {

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -28,10 +28,11 @@ public class SimpleGetHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -18,10 +19,8 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders() + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody(request);
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -29,11 +28,10 @@ public class SimpleGetHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
         String statusCode = StatusCode.OK.getStatusCode();
         String statusText = String.valueOf(StatusCode.OK);
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return request.getHttpVersion() + Constant.SP + statusCode + Constant.SP + statusText;
     }
 
     private String handleHeaders() {

--- a/src/main/java/org/httpserver/server/HttpMethod.java
+++ b/src/main/java/org/httpserver/server/HttpMethod.java
@@ -4,7 +4,8 @@ public enum HttpMethod {
     GET("GET"),
     POST("POST"),
     HEAD("HEAD"),
-    OPTIONS("OPTIONS");
+    OPTIONS("OPTIONS"),
+    PUT("PUT");
 
 
     private final String httpMethod;

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -19,7 +19,7 @@ public class Router {
             put("/simple_get", new SimpleGetHandler());
             put("/simple_get_with_body", new SimpleGetHandler());
             put("/head_request", new HeadRequestHandler());
-            put("/method_options", new OptionHandler());
+            put("/method_options", new OptionsHandler());
         }};
     }
 

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -20,6 +20,7 @@ public class Router {
             put("/simple_get_with_body", new SimpleGetHandler());
             put("/head_request", new HeadRequestHandler());
             put("/method_options", new OptionsHandler());
+            put("/method_options2", new OptionsHandler());
         }};
     }
 

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -20,7 +20,7 @@ public class Router {
             put("/simple_get_with_body", new SimpleGetHandler());
             put("/head_request", new HeadRequestHandler());
             put("/method_options", new OptionsHandler());
-            put("/method_options2", new OptionsHandler());
+            put("/method_options2", new OptionsHandlerTwo());
         }};
     }
 

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -1,9 +1,6 @@
 package org.httpserver.server;
 
-import org.httpserver.handler.Handler;
-import org.httpserver.handler.HeadRequestHandler;
-import org.httpserver.handler.MethodNotAllowedHandler;
-import org.httpserver.handler.SimpleGetHandler;
+import org.httpserver.handler.*;
 import org.httpserver.request.Request;
 
 import java.util.HashMap;
@@ -22,6 +19,7 @@ public class Router {
             put("/simple_get", new SimpleGetHandler());
             put("/simple_get_with_body", new SimpleGetHandler());
             put("/head_request", new HeadRequestHandler());
+            put("/method_options", new OptionHandler());
         }};
     }
 

--- a/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
@@ -25,9 +25,7 @@ class HeadRequestHandlerTest {
             put("httpMethod", "HEAD");
             put("requestTarget", "/head_request");
         }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request mockRequest = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request mockRequest = new Request(requestLineStub, new LinkedHashMap<>(), "");
         HeadRequestHandler headRequestHandler = new HeadRequestHandler();
 
         Response actual = headRequestHandler.handleResponse(mockRequest);

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -25,9 +25,7 @@ class MethodNotAllowedHandlerTest {
             put("httpMethod", "GET");
             put("requestTarget", "/head_request");
         }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request mockRequest = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request mockRequest = new Request(requestLineStub, new LinkedHashMap<>(), "");
         MethodNotAllowedHandler methodNotAllowedHandler = new MethodNotAllowedHandler();
 
         Response actual = methodNotAllowedHandler.handleResponse(mockRequest);

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -18,6 +18,7 @@ class OptionsHandlerTest {
         assertTrue(optionsHandler.allowedHttpMethods().contains("GET"));
         assertTrue(optionsHandler.allowedHttpMethods().contains("HEAD"));
         assertTrue(optionsHandler.allowedHttpMethods().contains("OPTIONS"));
+        assertEquals(3, optionsHandler.allowedHttpMethods().size());
     }
 
     @Test
@@ -36,25 +37,6 @@ class OptionsHandlerTest {
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertEquals("Allow: GET, HEAD, OPTIONS\r\n", actualResponse.getResponseHeaders());
-        assertTrue(actualResponse.getResponseBody().isEmpty());
-    }
-
-    @Test
-    void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptions2() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
-            put("httpVersion", "HTTP/1.1");
-            put("httpMethod", "OPTIONS");
-            put("requestTarget", "/method_options2");
-        }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        OptionsHandler optionsHandler = new OptionsHandler();
-
-        Response actualResponse = optionsHandler.handleResponse(requestMock);
-
-        assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        assertEquals("Allow: GET, HEAD, OPTIONS, PUT, POST\r\n", actualResponse.getResponseHeaders());
         assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 }

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -21,10 +21,10 @@ class OptionsHandlerTest {
     }
 
     @Test
-    void returnsResponseWithResponseStatusLineHeadersAndEmptyBody() {
+    void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptions() {
         LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
             put("httpVersion", "HTTP/1.1");
-            put("httpMethod", "OPTIONS");
+            put("httpMethod", "GET");
             put("requestTarget", "/method_options");
         }};
         LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
@@ -36,6 +36,25 @@ class OptionsHandlerTest {
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertEquals("Allow: GET, HEAD, OPTIONS\r\n", actualResponse.getResponseHeaders());
+        assertTrue(actualResponse.getResponseBody().isEmpty());
+    }
+
+    @Test
+    void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptions2() {
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+            put("httpVersion", "HTTP/1.1");
+            put("httpMethod", "OPTIONS");
+            put("requestTarget", "/method_options2");
+        }};
+        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
+        String requestBodyStub = "";
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        OptionsHandler optionsHandler = new OptionsHandler();
+
+        Response actualResponse = optionsHandler.handleResponse(requestMock);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
+        assertEquals("Allow: GET, HEAD, OPTIONS, PUT, POST\r\n", actualResponse.getResponseHeaders());
         assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 }

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -1,0 +1,18 @@
+package org.httpserver.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OptionsHandlerTest {
+
+    @Test
+    void returnsGetHeadAndOptionsMethodsOnly() {
+        OptionsHandler optionsHandler = new OptionsHandler();
+
+        assertTrue(optionsHandler.allowedHttpMethods().contains("GET"));
+        assertTrue(optionsHandler.allowedHttpMethods().contains("HEAD"));
+        assertTrue(optionsHandler.allowedHttpMethods().contains("OPTIONS"));
+    }
+
+}

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -36,7 +36,7 @@ class OptionsHandlerTest {
         Response actualResponse = optionsHandler.handleResponse(requestMock);
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        assertEquals("Allow: GET, HEAD, OPTIONS\r\n", actualResponse.getResponseHeaders());
+        assertEquals("Allow: GET, HEAD, OPTIONS\r\n\r\n", actualResponse.getResponseHeaders());
         assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 }

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -1,7 +1,12 @@
 package org.httpserver.handler;
 
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OptionsHandlerTest {
@@ -15,4 +20,22 @@ class OptionsHandlerTest {
         assertTrue(optionsHandler.allowedHttpMethods().contains("OPTIONS"));
     }
 
+    @Test
+    void returnsResponseWithResponseStatusLineHeadersAndEmptyBody() {
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+            put("httpVersion", "HTTP/1.1");
+            put("httpMethod", "OPTIONS");
+            put("requestTarget", "/method_options");
+        }};
+        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
+        String requestBodyStub = "";
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        OptionsHandler optionsHandler = new OptionsHandler();
+
+        Response actualResponse = optionsHandler.handleResponse(requestMock);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
+        assertEquals("Allow: GET, HEAD, OPTIONS\r\n", actualResponse.getResponseHeaders());
+        assertTrue(actualResponse.getResponseBody().isEmpty());
+    }
 }

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -28,9 +28,7 @@ class OptionsHandlerTest {
             put("httpMethod", "GET");
             put("requestTarget", "/method_options");
         }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         OptionsHandler optionsHandler = new OptionsHandler();
 
         Response actualResponse = optionsHandler.handleResponse(requestMock);

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
@@ -37,7 +37,7 @@ class OptionsHandlerTwoTest {
         Response actualResponse = optionsHandlerTwo.handleResponse(requestMock);
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        assertEquals("Allow: GET, HEAD, OPTIONS, PUT, POST\r\n", actualResponse.getResponseHeaders());
+        assertEquals("Allow: GET, HEAD, OPTIONS, PUT, POST\r\n\r\n", actualResponse.getResponseHeaders());
         assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 }

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
@@ -1,0 +1,43 @@
+package org.httpserver.handler;
+
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OptionsHandlerTwoTest {
+
+    @Test
+    void returnsGetHeadOptionsPostPutMethodsOnly() {
+        OptionsHandlerTwo optionsHandlerTwo = new OptionsHandlerTwo();
+
+        assertTrue(optionsHandlerTwo.allowedHttpMethods().contains("GET"));
+        assertTrue(optionsHandlerTwo.allowedHttpMethods().contains("HEAD"));
+        assertTrue(optionsHandlerTwo.allowedHttpMethods().contains("OPTIONS"));
+        assertTrue(optionsHandlerTwo.allowedHttpMethods().contains("POST"));
+        assertTrue(optionsHandlerTwo.allowedHttpMethods().contains("PUT"));
+        assertEquals(5, optionsHandlerTwo.allowedHttpMethods().size());
+    }
+
+    @Test
+    void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptionsTwo() {
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+            put("httpVersion", "HTTP/1.1");
+            put("httpMethod", "OPTIONS");
+            put("requestTarget", "/method_options2");
+        }};
+        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
+        String requestBodyStub = "";
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        OptionsHandlerTwo optionsHandlerTwo = new OptionsHandlerTwo();
+
+        Response actualResponse = optionsHandlerTwo.handleResponse(requestMock);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
+        assertEquals("Allow: GET, HEAD, OPTIONS, PUT, POST\r\n", actualResponse.getResponseHeaders());
+        assertTrue(actualResponse.getResponseBody().isEmpty());
+    }
+}

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
@@ -29,9 +29,7 @@ class OptionsHandlerTwoTest {
             put("httpMethod", "OPTIONS");
             put("requestTarget", "/method_options2");
         }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         OptionsHandlerTwo optionsHandlerTwo = new OptionsHandlerTwo();
 
         Response actualResponse = optionsHandlerTwo.handleResponse(requestMock);

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SimpleGetHandlerTest {
 
     private LinkedHashMap<String, String> requestLineStub;
-    private LinkedHashMap<String, String> requestHeadersStub;
-    private String requestBodyStub;
 
     @BeforeEach
     void setup() {
@@ -25,8 +23,6 @@ class SimpleGetHandlerTest {
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
         }};
-        requestHeadersStub = new LinkedHashMap<>();
-        requestBodyStub = "";
     }
 
     @Test
@@ -41,7 +37,7 @@ class SimpleGetHandlerTest {
     @Test
     void returnsResponseWithResponseStatusLineOnly() {
         requestLineStub.put("requestTarget", "/simple_get");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
 
         Response actualResponse = simpleGetHandler.handleResponse(requestMock);
@@ -54,7 +50,7 @@ class SimpleGetHandlerTest {
     @Test
     void returnsResponseWithResponseStatusLineAndBody() {
         requestLineStub.put("requestTarget", "/simple_get_with_body");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
 
         Response actualResponse = simpleGetHandler.handleResponse(requestMock);

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -35,6 +35,7 @@ class SimpleGetHandlerTest {
 
         assertTrue(simpleGetHandler.allowedHttpMethods().contains("GET"));
         assertTrue(simpleGetHandler.allowedHttpMethods().contains("HEAD"));
+        assertEquals(2, simpleGetHandler.allowedHttpMethods().size());
     }
 
     @Test

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -30,7 +30,7 @@ class SimpleGetHandlerTest {
     }
 
     @Test
-    void allowedMethods_returnsGe_AndHead_MethodsOnly() {
+    void returnsGetHeadAndMethodsOnly() {
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
 
         assertTrue(simpleGetHandler.allowedHttpMethods().contains("GET"));
@@ -38,7 +38,7 @@ class SimpleGetHandlerTest {
     }
 
     @Test
-    void handleResponse_ReturnsResponseWith_ResponseStatusLineOnly() {
+    void returnsResponseWithResponseStatusLineOnly() {
         requestLineStub.put("requestTarget", "/simple_get");
         Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
@@ -51,7 +51,7 @@ class SimpleGetHandlerTest {
     }
 
     @Test
-    void handleResponse_ReturnsResponseWith_ResponseStatusLine_AndBody() {
+    void returnsResponseWithResponseStatusLineAndBody() {
         requestLineStub.put("requestTarget", "/simple_get_with_body");
         Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -88,4 +88,16 @@ class RouterTest {
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
+    @Test
+    void returnOptionsHandler_whenMethodOptions2Route() {
+        requestLineStub.put("httpMethod", "OPTIONS");
+        requestLineStub.put("requestTarget", "/method_options2");
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Router router = new Router();
+
+        OptionsHandler expectedHandler = new OptionsHandler();
+        Handler actualHandler = router.getHandler(requestMock);
+
+        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+    }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -1,9 +1,6 @@
 package org.httpserver.server;
 
-import org.httpserver.handler.Handler;
-import org.httpserver.handler.HeadRequestHandler;
-import org.httpserver.handler.MethodNotAllowedHandler;
-import org.httpserver.handler.SimpleGetHandler;
+import org.httpserver.handler.*;
 import org.httpserver.request.Request;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,5 +76,16 @@ class RouterTest {
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
 
+    @Test
+    void returnOptionsHandler_whenMethodOptionsRoute() {
+        requestLineStub.put("httpMethod", "OPTIONS");
+        requestLineStub.put("requestTarget", "/method_options");
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Router router = new Router();
 
+        OptionHandler expectedHandler = new OptionHandler();
+        Handler actualHandler = router.getHandler(requestMock);
+
+        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+    }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -83,7 +83,7 @@ class RouterTest {
         Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
         Router router = new Router();
 
-        OptionHandler expectedHandler = new OptionHandler();
+        OptionsHandler expectedHandler = new OptionsHandler();
         Handler actualHandler = router.getHandler(requestMock);
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -89,13 +89,13 @@ class RouterTest {
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
     @Test
-    void returnOptionsHandler_whenMethodOptions2Route() {
+    void returnOptionsHandlerTwo_whenMethodOptions2Route() {
         requestLineStub.put("httpMethod", "OPTIONS");
         requestLineStub.put("requestTarget", "/method_options2");
         Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
         Router router = new Router();
 
-        OptionsHandler expectedHandler = new OptionsHandler();
+        OptionsHandlerTwo expectedHandler = new OptionsHandlerTwo();
         Handler actualHandler = router.getHandler(requestMock);
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());


### PR DESCRIPTION
This ticket focuses on handling OPTIONS routes, '/method_options' and 'method_options2' using test driven development with changes made to the following classes. 
- 'Router' - update 'createResourceAndHandlerMap' method by assigning requested target the correct handle
- 'OptionsHandler' and OptionsHandlerTwo' - test allowedMethods and response are correct 

Acceptance test: 27 successful (Simple GET, Simple HEAD, Simple OPTIONS, Method Not Allowed)