### PR TITLE
Redirect & Page Not Found

### DIFF
--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -14,6 +14,10 @@ public class EchoBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withBody(request.getRequestBody()).build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .withBody(request.getRequestBody())
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -20,7 +19,8 @@ public class EchoBodyHandler implements Handler {
         String responseHeaders = handleHeaders("", "") + Constant.CRLF;
         String responseBody = handleBody(request.getRequestBody());
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+
+
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 }

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -16,7 +16,7 @@ public class EchoBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody(request);
 
@@ -24,13 +24,6 @@ public class EchoBodyHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.OK.getStatusCode();
-        String statusText = String.valueOf(StatusCode.OK);
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "";

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -15,6 +14,6 @@ public class EchoBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody(request.getRequestBody()).build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withBody(request.getRequestBody()).build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -15,12 +15,6 @@ public class EchoBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
-        String responseBody = handleBody(request.getRequestBody());
-
-
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody(request.getRequestBody()).build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -17,19 +17,10 @@ public class EchoBodyHandler implements Handler {
 
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF;
-        String responseBody = handleBody(request);
+        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
+        String responseBody = handleBody(request.getRequestBody());
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-
-    private String handleHeaders() {
-        return "";
-    }
-
-    private String handleBody(Request request) {
-        return request.getRequestBody();
     }
 }

--- a/src/main/java/org/httpserver/handler/Handler.java
+++ b/src/main/java/org/httpserver/handler/Handler.java
@@ -2,7 +2,7 @@ package org.httpserver.handler;
 
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.server.HttpMethod;
+import org.httpserver.response.StatusCode;
 
 import java.util.List;
 
@@ -11,5 +11,12 @@ public interface Handler {
 
     Response handleResponse(Request request);
 
+    default String handleStatusLine(Request request, StatusCode statusText) {
+        String httpVersion = request.getHttpVersion();
+        String statusCode = statusText.getStatusCode();
+        String statusTextString = String.valueOf(statusText).replace("_", " ");
+
+        return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
+    }
 
 }

--- a/src/main/java/org/httpserver/handler/Handler.java
+++ b/src/main/java/org/httpserver/handler/Handler.java
@@ -5,6 +5,7 @@ import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
 
 import java.util.List;
+import java.util.Objects;
 
 public interface Handler {
     List<String> allowedHttpMethods();
@@ -17,6 +18,22 @@ public interface Handler {
         String statusTextString = String.valueOf(statusText).replace("_", " ");
 
         return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
+    }
+
+    default String handleHeaders(String header, String value) {
+        if (Objects.equals(header, "") && Objects.equals(value, "")) {
+            return "";
+        } else {
+            return header + ": " + value;
+        }
+    }
+
+    default String handleBody(String body) {
+        if (Objects.equals(body, "")) {
+            return "";
+        } else {
+            return body;
+        }
     }
 
 }

--- a/src/main/java/org/httpserver/handler/Handler.java
+++ b/src/main/java/org/httpserver/handler/Handler.java
@@ -11,24 +11,4 @@ public interface Handler {
     List<String> allowedHttpMethods();
 
     Response handleResponse(Request request);
-
-    default String handleStatusLine(Request request, StatusCode statusText) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = statusText.getStatusCode();
-        String statusTextString = String.valueOf(statusText).replace("_", " ");
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
-    }
-
-    default String handleHeaders(String headerName, String headerValue) {
-        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue;
-    }
-
-    private boolean isNoHeader(String headerName, String headerValue) {
-        return Objects.equals(headerName, "") && Objects.equals(headerValue, "");
-    }
-
-    default String handleBody(String responseBody) {
-        return Objects.equals(responseBody, "") ? "" : responseBody;
-    }
 }

--- a/src/main/java/org/httpserver/handler/Handler.java
+++ b/src/main/java/org/httpserver/handler/Handler.java
@@ -20,19 +20,19 @@ public interface Handler {
         return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
     }
 
-    default String handleHeaders(String header, String value) {
-        if (Objects.equals(header, "") && Objects.equals(value, "")) {
+    default String handleHeaders(String headerName, String headerValue) {
+        if (Objects.equals(headerName, "") && Objects.equals(headerValue, "")) {
             return "";
         } else {
-            return header + ": " + value;
+            return headerName + ": " + headerValue;
         }
     }
 
-    default String handleBody(String body) {
-        if (Objects.equals(body, "")) {
+    default String handleBody(String responseBody) {
+        if (Objects.equals(responseBody, "")) {
             return "";
         } else {
-            return body;
+            return responseBody;
         }
     }
 

--- a/src/main/java/org/httpserver/handler/Handler.java
+++ b/src/main/java/org/httpserver/handler/Handler.java
@@ -21,19 +21,14 @@ public interface Handler {
     }
 
     default String handleHeaders(String headerName, String headerValue) {
-        if (Objects.equals(headerName, "") && Objects.equals(headerValue, "")) {
-            return "";
-        } else {
-            return headerName + ": " + headerValue;
-        }
+        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue;
+    }
+
+    private boolean isNoHeader(String headerName, String headerValue) {
+        return Objects.equals(headerName, "") && Objects.equals(headerValue, "");
     }
 
     default String handleBody(String responseBody) {
-        if (Objects.equals(responseBody, "")) {
-            return "";
-        } else {
-            return responseBody;
-        }
+        return Objects.equals(responseBody, "") ? "" : responseBody;
     }
-
 }

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -15,6 +14,6 @@ public class HeadRequestHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -17,20 +17,11 @@ public class HeadRequestHandler implements Handler {
 
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF;
-        String responseBody = handleBody();
+        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
 
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-
-    private String handleHeaders() {
-        return "";
-    }
-
-    private String handleBody() {
-        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -16,7 +16,7 @@ public class HeadRequestHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody();
 
@@ -25,13 +25,6 @@ public class HeadRequestHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.OK.getStatusCode();
-        String statusText = String.valueOf(StatusCode.OK);
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "";

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -20,8 +19,9 @@ public class HeadRequestHandler implements Handler {
         String responseHeaders = handleHeaders("", "") + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
 
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
+
+
     }
 }

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -14,6 +14,9 @@ public class HeadRequestHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/HeadRequestHandler.java
+++ b/src/main/java/org/httpserver/handler/HeadRequestHandler.java
@@ -15,13 +15,6 @@ public class HeadRequestHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
-        String responseBody = handleBody("");
-
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
-
-
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -22,7 +21,7 @@ public class MethodNotAllowedHandler implements Handler {
         String responseHeaders = handleHeaders("Allow", "HEAD, OPTIONS") + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -17,6 +16,6 @@ public class MethodNotAllowedHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.METHOD_NOT_ALLOWED).withHeaderName("Allow").withHeaderValue("HEAD, OPTIONS").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.METHOD_NOT_ALLOWED).withHeaderName("Allow").withHeaderValue("HEAD, OPTIONS").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -17,11 +17,6 @@ public class MethodNotAllowedHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.METHOD_NOT_ALLOWED) + Constant.CRLF;
-        String responseHeaders = handleHeaders("Allow", "HEAD, OPTIONS") + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody("");
-
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.METHOD_NOT_ALLOWED).withHeaderName("Allow").withHeaderValue("HEAD, OPTIONS").withBody("").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -19,20 +19,10 @@ public class MethodNotAllowedHandler implements Handler {
     @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.METHOD_NOT_ALLOWED) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody();
+        String responseHeaders = handleHeaders("Allow", "HEAD, OPTIONS") + Constant.CRLF + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-
-
-    private String handleHeaders() {
-        return "Allow: HEAD, OPTIONS";
-    }
-
-    private String handleBody() {
-        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -18,7 +18,7 @@ public class MethodNotAllowedHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.METHOD_NOT_ALLOWED) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
@@ -26,13 +26,7 @@ public class MethodNotAllowedHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.METHOD_NOT_ALLOWED.getStatusCode();
-        String statusText = String.valueOf(StatusCode.METHOD_NOT_ALLOWED).replace("_", " ");
 
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "Allow: HEAD, OPTIONS";

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -16,6 +16,11 @@ public class MethodNotAllowedHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.METHOD_NOT_ALLOWED).withHeaderName("Allow").withHeaderValue("HEAD, OPTIONS").build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.METHOD_NOT_ALLOWED)
+                .withStatusCodeText(StatusCode.METHOD_NOT_ALLOWED.name().replace("_", " "))
+                .withHeaderName("Allow")
+                .withHeaderValue("HEAD, OPTIONS")
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -23,8 +22,7 @@ public class OptionsHandler implements Handler {
         String responseHeaders = handleHeaders("Allow","GET, HEAD, OPTIONS" ) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 
 

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -19,7 +19,7 @@ public class OptionsHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
         String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
@@ -27,13 +27,6 @@ public class OptionsHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.OK.getStatusCode();
-        String statusText = String.valueOf(StatusCode.OK);
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders(Request request) {
         return "Allow: GET, HEAD, OPTIONS";

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -18,11 +18,7 @@ public class OptionsHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("Allow","GET, HEAD, OPTIONS" ) + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody("");
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS").withBody("").build(request);
     }
 
 

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -15,14 +14,8 @@ public class OptionsHandler implements Handler {
         return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());
     }
 
-
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS").build(request);
     }
-
-
-
-
-
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -16,6 +16,11 @@ public class OptionsHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS").build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .withHeaderName("Allow")
+                .withHeaderValue("GET, HEAD, OPTIONS")
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -20,18 +20,10 @@ public class OptionsHandlerTwo implements Handler {
     @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody();
+        String responseHeaders = handleHeaders("Allow", "GET, HEAD, OPTIONS, PUT, POST") + Constant.CRLF + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-    private String handleHeaders(Request request) {
-        return "Allow: GET, HEAD, OPTIONS, PUT, POST";
-    }
-
-    private String handleBody() {
-        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -19,20 +19,12 @@ public class OptionsHandlerTwo implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
         String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.OK.getStatusCode();
-        String statusText = String.valueOf(StatusCode.OK);
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -18,6 +17,6 @@ public class OptionsHandlerTwo implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS, PUT, POST").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS, PUT, POST").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -18,10 +18,6 @@ public class OptionsHandlerTwo implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("Allow", "GET, HEAD, OPTIONS, PUT, POST") + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody("");
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS, PUT, POST").withBody("").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -23,7 +22,6 @@ public class OptionsHandlerTwo implements Handler {
         String responseHeaders = handleHeaders("Allow", "GET, HEAD, OPTIONS, PUT, POST") + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -17,6 +17,11 @@ public class OptionsHandlerTwo implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("Allow").withHeaderValue("GET, HEAD, OPTIONS, PUT, POST").build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .withHeaderName("Allow")
+                .withHeaderValue("GET, HEAD, OPTIONS, PUT, POST")
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -1,12 +1,15 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
+import org.httpserver.response.ResponseBuilder;
+import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
 import java.util.List;
 
-public class PageNotFoundHandler implements Handler{
+public class PageNotFoundHandler implements Handler {
     @Override
     public List<String> allowedHttpMethods() {
         return List.of(HttpMethod.GET.getHttpMethod());
@@ -14,6 +17,27 @@ public class PageNotFoundHandler implements Handler{
 
     @Override
     public Response handleResponse(Request request) {
-        return null;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders() + Constant.CRLF;
+        String responseBody = handleBody();
+
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+    }
+
+    private String handleStatusLine(Request request) {
+        String httpVersion = request.getHttpVersion();
+        String statusCode = StatusCode.NOT_FOUND.getStatusCode();
+        String statusText = String.valueOf(StatusCode.NOT_FOUND).replace("_", " ");
+
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
+    }
+
+    private String handleHeaders() {
+        return "";
+    }
+
+    private String handleBody() {
+        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -16,6 +16,9 @@ public class PageNotFoundHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.NOT_FOUND).build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.NOT_FOUND)
+                .withStatusCodeText(StatusCode.NOT_FOUND.name().replace("_", " "))
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -16,14 +16,6 @@ public class PageNotFoundHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.NOT_FOUND) + Constant.CRLF;
-        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
-        String responseBody = handleBody("");
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.NOT_FOUND).withHeaderName("").withHeaderValue("").withBody("").build(request);
     }
-
-
-
-
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -17,7 +17,7 @@ public class PageNotFoundHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.NOT_FOUND) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody();
 
@@ -25,13 +25,7 @@ public class PageNotFoundHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.NOT_FOUND.getStatusCode();
-        String statusText = String.valueOf(StatusCode.NOT_FOUND).replace("_", " ");
 
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "";

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -1,0 +1,19 @@
+package org.httpserver.handler;
+
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
+import org.httpserver.server.HttpMethod;
+
+import java.util.List;
+
+public class PageNotFoundHandler implements Handler{
+    @Override
+    public List<String> allowedHttpMethods() {
+        return List.of(HttpMethod.GET.getHttpMethod());
+    }
+
+    @Override
+    public Response handleResponse(Request request) {
+        return null;
+    }
+}

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -16,6 +16,6 @@ public class PageNotFoundHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.NOT_FOUND).withHeaderName("").withHeaderValue("").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.NOT_FOUND).build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -18,8 +18,8 @@ public class PageNotFoundHandler implements Handler {
     @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.NOT_FOUND) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF;
-        String responseBody = handleBody();
+        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
@@ -27,11 +27,5 @@ public class PageNotFoundHandler implements Handler {
 
 
 
-    private String handleHeaders() {
-        return "";
-    }
 
-    private String handleBody() {
-        return "";
-    }
 }

--- a/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
+++ b/src/main/java/org/httpserver/handler/PageNotFoundHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -21,8 +20,7 @@ public class PageNotFoundHandler implements Handler {
         String responseHeaders = handleHeaders("", "") + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 
 

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -2,6 +2,8 @@ package org.httpserver.handler;
 
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
+import org.httpserver.response.ResponseBuilder;
+import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
 import java.util.List;
@@ -14,6 +16,29 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return null;
+        String CRLF = "\r\n";
+
+        String responseStatusLine = handleStatusLine(request) + CRLF;
+        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
+        String responseBody = handleBody();
+
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+    }
+
+    private String handleStatusLine(Request request) {
+        String SP = " ";
+        String statusCode = StatusCode.MOVED_PERMANENTLY.getStatusCode();
+        String statusText = String.valueOf(StatusCode.MOVED_PERMANENTLY).replace("_"," ");
+
+        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+    }
+
+    private String handleHeaders(Request request) {
+        return "Location: http://127.0.0.1:5000/simple_get";
+    }
+
+    private String handleBody() {
+        return "";
     }
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -18,7 +18,7 @@ public class RedirectHandler implements Handler {
     @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
-        String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
+        String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -33,7 +33,7 @@ public class RedirectHandler implements Handler {
         return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
-    private String handleHeaders(Request request) {
+    private String handleHeaders() {
         return "Location: http://127.0.0.1:5000/simple_get";
     }
 

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -1,5 +1,6 @@
 package org.httpserver.handler;
 
+import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
@@ -16,10 +17,8 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String CRLF = "\r\n";
-
-        String responseStatusLine = handleStatusLine(request) + CRLF;
-        String responseHeaders = handleHeaders(request) + CRLF + CRLF;
+        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseHeaders = handleHeaders(request) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
@@ -27,11 +26,11 @@ public class RedirectHandler implements Handler {
     }
 
     private String handleStatusLine(Request request) {
-        String SP = " ";
+        String httpVersion = request.getHttpVersion();
         String statusCode = StatusCode.MOVED_PERMANENTLY.getStatusCode();
-        String statusText = String.valueOf(StatusCode.MOVED_PERMANENTLY).replace("_"," ");
+        String statusText = String.valueOf(StatusCode.MOVED_PERMANENTLY).replace("_", " ");
 
-        return request.getHttpVersion() + SP + statusCode + SP + statusText;
+        return String.format("%s %s %s", httpVersion, statusCode, statusText);
     }
 
     private String handleHeaders(Request request) {

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -1,0 +1,19 @@
+package org.httpserver.handler;
+
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
+import org.httpserver.server.HttpMethod;
+
+import java.util.List;
+
+public class RedirectHandler implements Handler {
+    @Override
+    public List<String> allowedHttpMethods() {
+        return List.of(HttpMethod.GET.getHttpMethod());
+    }
+
+    @Override
+    public Response handleResponse(Request request) {
+        return null;
+    }
+}

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -21,8 +20,7 @@ public class RedirectHandler implements Handler {
         String responseHeaders = handleHeaders("Location","http://127.0.0.1:5000/simple_get" ) + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -17,7 +17,7 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.MOVED_PERMANENTLY) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
         String responseBody = handleBody();
 
@@ -25,13 +25,6 @@ public class RedirectHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.MOVED_PERMANENTLY.getStatusCode();
-        String statusText = String.valueOf(StatusCode.MOVED_PERMANENTLY).replace("_", " ");
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "Location: http://127.0.0.1:5000/simple_get";

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -18,19 +18,11 @@ public class RedirectHandler implements Handler {
     @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.MOVED_PERMANENTLY) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody();
+        String responseHeaders = handleHeaders("Location","http://127.0.0.1:5000/simple_get" ) + Constant.CRLF + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-
-    private String handleHeaders() {
-        return "Location: http://127.0.0.1:5000/simple_get";
-    }
-
-    private String handleBody() {
-        return "";
-    }
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -15,6 +15,10 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.MOVED_PERMANENTLY).withHeaderName("Location").withHeaderValue("http://127.0.0.1:5000/simple_get").build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.MOVED_PERMANENTLY)
+                .withStatusCodeText(StatusCode.MOVED_PERMANENTLY.name().replace("_", " "))
+                .withHeaderName("Location").withHeaderValue("http://127.0.0.1:5000/simple_get")
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -16,7 +15,6 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.MOVED_PERMANENTLY).withHeaderName("Location").withHeaderValue("http://127.0.0.1:5000/simple_get").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.MOVED_PERMANENTLY).withHeaderName("Location").withHeaderValue("http://127.0.0.1:5000/simple_get").build(request);
     }
-
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -16,11 +16,7 @@ public class RedirectHandler implements Handler {
 
     @Override
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.MOVED_PERMANENTLY) + Constant.CRLF;
-        String responseHeaders = handleHeaders("Location","http://127.0.0.1:5000/simple_get" ) + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody("");
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().withStatusCode(StatusCode.MOVED_PERMANENTLY).withHeaderName("Location").withHeaderValue("http://127.0.0.1:5000/simple_get").withBody("").build(request);
     }
 
 }

--- a/src/main/java/org/httpserver/handler/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/handler/ResponseBuilder.java
@@ -9,7 +9,32 @@ import java.util.Objects;
 
 public class ResponseBuilder {
 
-    public Response build(Request request, StatusCode statusCode, String headerName, String headerValue, String body) {
+    private StatusCode statusCode;
+    private String headerName;
+    private String headerValue;
+    private String body;
+
+    ResponseBuilder withStatusCode(StatusCode statusCode){
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    ResponseBuilder withHeaderName(String headerName){
+        this.headerName = headerName;
+        return this;
+    }
+
+    ResponseBuilder withHeaderValue(String headerValue){
+        this.headerValue = headerValue;
+        return this;
+    }
+
+    ResponseBuilder withBody(String body){
+        this.body = body;
+        return this;
+    }
+
+    public Response build(Request request) {
         String responseStatusLine = handleStatusLine(request, statusCode) + Constant.CRLF;
         String responseHeaders = handleHeaders(headerName, headerValue) + Constant.CRLF;
         String responseBody = handleBody(body);

--- a/src/main/java/org/httpserver/handler/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/handler/ResponseBuilder.java
@@ -1,21 +1,31 @@
 package org.httpserver.handler;
 
 import org.httpserver.Constant;
-import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
 
 import java.util.Objects;
 
 public class ResponseBuilder {
+    private String httpVersion = "HTTP/1.1";
 
     private StatusCode statusCode;
     private String headerName = "";
     private String headerValue = "";
     private String body = "";
+    private String statusCodeText;
 
+    public ResponseBuilder withHttpVersion(String httpVersion) {
+        this.httpVersion = httpVersion;
+        return this;
+    }
     ResponseBuilder withStatusCode(StatusCode statusCode){
         this.statusCode = statusCode;
+        return this;
+    }
+
+    ResponseBuilder withStatusCodeText(String statusCodeText){
+        this.statusCodeText = statusCodeText;
         return this;
     }
 
@@ -34,30 +44,22 @@ public class ResponseBuilder {
         return this;
     }
 
-    public Response build(Request request) {
-        String responseStatusLine = handleStatusLine(request, statusCode) + Constant.CRLF;
-        String responseHeaders = handleHeaders(headerName, headerValue) + Constant.CRLF;
-        String responseBody = handleBody(body);
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+    public Response build() {
+        return new Response(handleStatusLine(), handleHeaders(), handleBody());
     }
 
-    private String handleStatusLine(Request request, StatusCode statusText) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = statusText.getStatusCode();
-        String statusTextString = String.valueOf(statusText).replace("_", " ");
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
+    private String handleStatusLine() {
+        return String.format("%s %s %s", httpVersion, statusCode.getStatusCode(), statusCodeText) + Constant.CRLF;
+    }
+    private String handleHeaders() {
+        return (isNoHeader() ? "" : headerName + ": " + headerValue + Constant.CRLF) + Constant.CRLF;
     }
 
-    private String handleHeaders(String headerName, String headerValue) {
-        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue + Constant.CRLF;
-    }
-
-    private boolean isNoHeader(String headerName, String headerValue) {
+    private boolean isNoHeader() {
         return Objects.equals(headerName, "") && Objects.equals(headerValue, "");
     }
 
-    private String handleBody(String responseBody) {
-        return Objects.equals(responseBody, "") ? "" : responseBody;
+    private String handleBody() {
+        return Objects.equals(body, "") ? "" : body;
     }
 }

--- a/src/main/java/org/httpserver/handler/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/handler/ResponseBuilder.java
@@ -50,7 +50,7 @@ public class ResponseBuilder {
     }
 
     private String handleHeaders(String headerName, String headerValue) {
-        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue;
+        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue + Constant.CRLF;
     }
 
     private boolean isNoHeader(String headerName, String headerValue) {

--- a/src/main/java/org/httpserver/handler/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/handler/ResponseBuilder.java
@@ -10,9 +10,9 @@ import java.util.Objects;
 public class ResponseBuilder {
 
     private StatusCode statusCode;
-    private String headerName;
-    private String headerValue;
-    private String body;
+    private String headerName = "";
+    private String headerValue = "";
+    private String body = "";
 
     ResponseBuilder withStatusCode(StatusCode statusCode){
         this.statusCode = statusCode;

--- a/src/main/java/org/httpserver/handler/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/handler/ResponseBuilder.java
@@ -1,0 +1,38 @@
+package org.httpserver.handler;
+
+import org.httpserver.Constant;
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
+import org.httpserver.response.StatusCode;
+
+import java.util.Objects;
+
+public class ResponseBuilder {
+
+    public Response build(Request request, StatusCode statusCode, String headerName, String headerValue, String body) {
+        String responseStatusLine = handleStatusLine(request, statusCode) + Constant.CRLF;
+        String responseHeaders = handleHeaders(headerName, headerValue) + Constant.CRLF;
+        String responseBody = handleBody(body);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
+    }
+
+    private String handleStatusLine(Request request, StatusCode statusText) {
+        String httpVersion = request.getHttpVersion();
+        String statusCode = statusText.getStatusCode();
+        String statusTextString = String.valueOf(statusText).replace("_", " ");
+
+        return String.format("%s %s %s", httpVersion, statusCode, statusTextString);
+    }
+
+    private String handleHeaders(String headerName, String headerValue) {
+        return isNoHeader(headerName, headerValue) ? "" : headerName + ": " + headerValue;
+    }
+
+    private boolean isNoHeader(String headerName, String headerValue) {
+        return Objects.equals(headerName, "") && Objects.equals(headerValue, "");
+    }
+
+    private String handleBody(String responseBody) {
+        return Objects.equals(responseBody, "") ? "" : responseBody;
+    }
+}

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -16,6 +16,6 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -17,10 +17,6 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
-        String responseBody = handleBody("");
-
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().build(request, StatusCode.OK, "", "", "");
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -19,7 +19,7 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request) + Constant.CRLF;
+        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
         String responseHeaders = handleHeaders() + Constant.CRLF;
         String responseBody = handleBody(request);
 
@@ -27,13 +27,6 @@ public class SimpleGetHandler implements Handler {
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
 
-    private String handleStatusLine(Request request) {
-        String httpVersion = request.getHttpVersion();
-        String statusCode = StatusCode.OK.getStatusCode();
-        String statusText = String.valueOf(StatusCode.OK);
-
-        return String.format("%s %s %s", httpVersion, statusCode, statusText);
-    }
 
     private String handleHeaders() {
         return "";

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -9,7 +9,6 @@ import org.httpserver.server.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 public class SimpleGetHandler implements Handler {
 
@@ -20,23 +19,10 @@ public class SimpleGetHandler implements Handler {
 
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders() + Constant.CRLF;
-        String responseBody = handleBody(request);
+        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
+        String responseBody = handleBody("");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
-    }
-
-
-    private String handleHeaders() {
-        return "";
-    }
-
-    private String handleBody(Request request) {
-        if (Objects.equals(request.getRequestTarget(), "/simple_get_with_body")) {
-            return "Hello world";
-        } else {
-            return "";
-        }
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -17,6 +16,6 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().build(request, StatusCode.OK, "", "", "");
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -16,6 +16,9 @@ public class SimpleGetHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -22,7 +21,6 @@ public class SimpleGetHandler implements Handler {
         String responseHeaders = handleHeaders("", "") + Constant.CRLF;
         String responseBody = handleBody("");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -15,6 +15,10 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withBody("Hello world").build(request);
+        return new ResponseBuilder()
+                .withStatusCode(StatusCode.OK)
+                .withStatusCodeText(StatusCode.OK.name())
+                .withBody("Hello world")
+                .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -16,8 +16,6 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().build(request, StatusCode.OK, "", "", "Hello world");
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("Hello world").build(request);
     }
-
-
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -16,12 +16,7 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        StatusCode statusCode = StatusCode.OK;
-        String headerName = "";
-        String headerValue = "";
-        String body = "Hello world";
-
-        return new ResponseBuilder().build(request, statusCode, headerName, headerValue, body);
+        return new ResponseBuilder().build(request, StatusCode.OK, "", "", "Hello world");
     }
 
 

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -16,10 +16,13 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
-        String responseBody = handleBody("Hello world");
+        StatusCode statusCode = StatusCode.OK;
+        String headerName = "";
+        String headerValue = "";
+        String body = "Hello world";
 
-        return new Response(responseStatusLine, responseHeaders, responseBody);
+        return new ResponseBuilder().build(request, statusCode, headerName, headerValue, body);
     }
+
+
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -1,6 +1,5 @@
 package org.httpserver.handler;
 
-import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
 import org.httpserver.response.StatusCode;
@@ -16,6 +15,6 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
-        return new ResponseBuilder().withStatusCode(StatusCode.OK).withHeaderName("").withHeaderValue("").withBody("Hello world").build(request);
+        return new ResponseBuilder().withStatusCode(StatusCode.OK).withBody("Hello world").build(request);
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -3,7 +3,6 @@ package org.httpserver.handler;
 import org.httpserver.Constant;
 import org.httpserver.request.Request;
 import org.httpserver.response.Response;
-import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
@@ -21,7 +20,6 @@ public class SimpleGetWithBodyHandler implements Handler {
         String responseHeaders = handleHeaders("", "") + Constant.CRLF;
         String responseBody = handleBody("Hello world");
 
-        ResponseBuilder responseBuilder = new ResponseBuilder();
-        return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
+        return new Response(responseStatusLine, responseHeaders, responseBody);
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -7,28 +7,21 @@ import org.httpserver.response.ResponseBuilder;
 import org.httpserver.response.StatusCode;
 import org.httpserver.server.HttpMethod;
 
-import java.util.Arrays;
 import java.util.List;
 
-public class OptionsHandler implements Handler {
+public class SimpleGetWithBodyHandler implements Handler {
+
     @Override
     public List<String> allowedHttpMethods() {
-        return Arrays.asList(HttpMethod.GET.getHttpMethod(), HttpMethod.HEAD.getHttpMethod(), HttpMethod.OPTIONS.getHttpMethod());
+        return List.of(HttpMethod.GET.getHttpMethod());
     }
 
-
-    @Override
     public Response handleResponse(Request request) {
         String responseStatusLine = handleStatusLine(request, StatusCode.OK) + Constant.CRLF;
-        String responseHeaders = handleHeaders("Allow","GET, HEAD, OPTIONS" ) + Constant.CRLF + Constant.CRLF;
-        String responseBody = handleBody("");
+        String responseHeaders = handleHeaders("", "") + Constant.CRLF;
+        String responseBody = handleBody("Hello world");
 
         ResponseBuilder responseBuilder = new ResponseBuilder();
         return responseBuilder.buildResponse(responseStatusLine, responseHeaders, responseBody);
     }
-
-
-
-
-
 }

--- a/src/main/java/org/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/response/ResponseBuilder.java
@@ -1,8 +1,0 @@
-package org.httpserver.response;
-
-public class ResponseBuilder {
-    public Response buildResponse(String responseStatusLine , String responseHeaders, String responseBody){
-        return new Response(responseStatusLine, responseHeaders, responseBody);
-    }
-
-}

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -29,7 +29,7 @@ public class Router {
     public Handler getHandler(Request request) {
         if (resourceTargetExists(request) && isHttpMethodAllowed(request)) {
             return resourceAndHandlerMap.get(request.getRequestTarget());
-        } else if (resourceTargetExists(request) && !isHttpMethodAllowed(request)){
+        } else if (resourceTargetExists(request) && !isHttpMethodAllowed(request)) {
             return new MethodNotAllowedHandler();
         } else {
             return new PageNotFoundHandler();

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -22,6 +22,7 @@ public class Router {
             put("/method_options", new OptionsHandler());
             put("/method_options2", new OptionsHandlerTwo());
             put("/echo_body", new EchoBodyHandler());
+            put("/redirect", new RedirectHandler());
         }};
     }
 

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -29,8 +29,11 @@ public class Router {
     public Handler getHandler(Request request) {
         if (resourceTargetExists(request) && isHttpMethodAllowed(request)) {
             return resourceAndHandlerMap.get(request.getRequestTarget());
+        } else if (resourceTargetExists(request) && !isHttpMethodAllowed(request)){
+            return new MethodNotAllowedHandler();
+        } else {
+            return new PageNotFoundHandler();
         }
-        return new MethodNotAllowedHandler();
     }
 
     private boolean resourceTargetExists(Request request) {

--- a/src/main/java/org/httpserver/server/Router.java
+++ b/src/main/java/org/httpserver/server/Router.java
@@ -17,7 +17,7 @@ public class Router {
     public Map<String, Handler> createResourceAndHandlerMap() {
         return new HashMap<>() {{
             put("/simple_get", new SimpleGetHandler());
-            put("/simple_get_with_body", new SimpleGetHandler());
+            put("/simple_get_with_body", new SimpleGetWithBodyHandler());
             put("/head_request", new HeadRequestHandler());
             put("/method_options", new OptionsHandler());
             put("/method_options2", new OptionsHandlerTwo());
@@ -44,6 +44,4 @@ public class Router {
         Handler handler = resourceAndHandlerMap.get(request.getRequestTarget());
         return handler.allowedHttpMethods().contains(request.getHttpMethod());
     }
-
-
 }

--- a/src/test/java/org/httpserver/handler/EchoBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/EchoBodyHandlerTest.java
@@ -21,7 +21,7 @@ class EchoBodyHandlerTest {
 
     @Test
     void returnsResponseWithStatusLineAndBodyOnly() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "POST");
             put("requestTarget", "/echo_body");

--- a/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
@@ -20,7 +20,7 @@ class HeadRequestHandlerTest {
 
     @Test
     void handleResponse_ReturnsResponseWith_ResponseStatusLineOnly() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "HEAD");
             put("requestTarget", "/head_request");

--- a/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/HeadRequestHandlerTest.java
@@ -16,6 +16,7 @@ class HeadRequestHandlerTest {
         HeadRequestHandler headRequestHandler = new HeadRequestHandler();
 
         assertTrue(headRequestHandler.allowedHttpMethods().contains("HEAD"));
+        assertEquals(1, headRequestHandler.allowedHttpMethods().size());
     }
 
     @Test

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -14,8 +14,10 @@ class MethodNotAllowedHandlerTest {
     void allowedMethods_returnsGetHeadAndOptionsMethodsOnly() {
         MethodNotAllowedHandler methodNotAllowedHandler = new MethodNotAllowedHandler();
 
+        assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("GET"));
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("HEAD"));
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("OPTIONS"));
+        assertEquals(3, methodNotAllowedHandler.allowedHttpMethods().size());
     }
 
     @Test

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -14,7 +14,6 @@ class MethodNotAllowedHandlerTest {
     void allowedMethods_returnsGetHeadAndOptionsMethodsOnly() {
         MethodNotAllowedHandler methodNotAllowedHandler = new MethodNotAllowedHandler();
 
-        assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("GET"));
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("HEAD"));
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("OPTIONS"));
         assertEquals(3, methodNotAllowedHandler.allowedHttpMethods().size());

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MethodNotAllowedHandlerTest {
 
     @Test
-    void allowedMethods_returnsGetHeadAndOptionsMethodsOnly() {
+    void allowedMethods_returnsHeadAndOptionsMethodsOnly() {
         MethodNotAllowedHandler methodNotAllowedHandler = new MethodNotAllowedHandler();
 
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("HEAD"));

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -20,7 +20,7 @@ class MethodNotAllowedHandlerTest {
 
     @Test
     void handleResponse_ReturnsResponseWith_ResponseStatusLine_AndHeadersOnly() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
             put("requestTarget", "/head_request");

--- a/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/MethodNotAllowedHandlerTest.java
@@ -16,7 +16,7 @@ class MethodNotAllowedHandlerTest {
 
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("HEAD"));
         assertTrue(methodNotAllowedHandler.allowedHttpMethods().contains("OPTIONS"));
-        assertEquals(3, methodNotAllowedHandler.allowedHttpMethods().size());
+        assertEquals(2, methodNotAllowedHandler.allowedHttpMethods().size());
     }
 
     @Test

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTest.java
@@ -23,7 +23,7 @@ class OptionsHandlerTest {
 
     @Test
     void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptions() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
             put("requestTarget", "/method_options");

--- a/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
+++ b/src/test/java/org/httpserver/handler/OptionsHandlerTwoTest.java
@@ -25,7 +25,7 @@ class OptionsHandlerTwoTest {
 
     @Test
     void returnsResponseWithStatusLineHeadersAndEmptyBody_whenMethodOptionsTwo() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "OPTIONS");
             put("requestTarget", "/method_options2");

--- a/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
@@ -26,10 +26,9 @@ class PageNotFoundHandlerTest {
             put("httpMethod", "GET");
             put("requestTarget", "/page_not_exist");
         }};
-        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         PageNotFoundHandler pageNotFoundHandler = new PageNotFoundHandler();
 
-        Response actualResponse = pageNotFoundHandler.handleResponse(requestMock);
+        Response actualResponse = pageNotFoundHandler.handleResponse(new Request(requestLineStub, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 404 NOT FOUND\r\n", actualResponse.getResponseStatusLine());
         assertTrue(actualResponse.getResponseHeaders().isBlank());

--- a/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
@@ -21,7 +21,7 @@ class PageNotFoundHandlerTest {
 
     @Test
     void returnsResponseWithStatusLineOnly(){
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
             put("requestTarget", "/page_not_exist");

--- a/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PageNotFoundHandlerTest {
 

--- a/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
@@ -1,0 +1,18 @@
+package org.httpserver.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PageNotFoundHandlerTest {
+
+    @Test
+    void returnsGetMethodOnly(){
+        PageNotFoundHandler pageNotFoundHandler = new PageNotFoundHandler();
+
+        assertTrue(pageNotFoundHandler.allowedHttpMethods().contains("GET"));
+        assertEquals(1, pageNotFoundHandler.allowedHttpMethods().size());
+    }
+
+
+}

--- a/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/PageNotFoundHandlerTest.java
@@ -1,6 +1,10 @@
 package org.httpserver.handler;
 
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,6 +16,23 @@ class PageNotFoundHandlerTest {
 
         assertTrue(pageNotFoundHandler.allowedHttpMethods().contains("GET"));
         assertEquals(1, pageNotFoundHandler.allowedHttpMethods().size());
+    }
+
+    @Test
+    void returnsResponseWithStatusLineOnly(){
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+            put("httpVersion", "HTTP/1.1");
+            put("httpMethod", "GET");
+            put("requestTarget", "/page_not_exist");
+        }};
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
+        PageNotFoundHandler pageNotFoundHandler = new PageNotFoundHandler();
+
+        Response actualResponse = pageNotFoundHandler.handleResponse(requestMock);
+
+        assertEquals("HTTP/1.1 404 NOT FOUND\r\n", actualResponse.getResponseStatusLine());
+        assertTrue(actualResponse.getResponseHeaders().isBlank());
+        assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 
 

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -18,7 +18,7 @@ class RedirectHandlerTest {
     }
 
     @Test
-    void returnsResponseWithStatusLineAndBodyOnly() {
+    void returnsResponseWithStatusLineAndHeaderOnly() {
         LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
@@ -33,6 +33,6 @@ class RedirectHandlerTest {
 
         assertEquals("HTTP/1.1 301 MOVED PERMANENTLY\r\n", actualResponse.getResponseStatusLine());
         assertEquals("Location: http://127.0.0.1:5000/simple_get\r\n\r\n", actualResponse.getResponseHeaders());
-        assertEquals(requestBodyStub, actualResponse.getResponseBody());
+        assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 }

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -1,6 +1,10 @@
 package org.httpserver.handler;
 
+import org.httpserver.request.Request;
+import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 class RedirectHandlerTest {
@@ -11,5 +15,24 @@ class RedirectHandlerTest {
 
         assertTrue(redirectHandler.allowedHttpMethods().contains("GET"));
         assertEquals(1, redirectHandler.allowedHttpMethods().size());
+    }
+
+    @Test
+    void returnsResponseWithStatusLineAndBodyOnly() {
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+            put("httpVersion", "HTTP/1.1");
+            put("httpMethod", "GET");
+            put("requestTarget", "/redirect");
+        }};
+        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
+        String requestBodyStub = "";
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        RedirectHandler redirectHandler = new RedirectHandler();
+
+        Response actualResponse = redirectHandler.handleResponse(requestMock);
+
+        assertEquals("HTTP/1.1 301 MOVED PERMANENTLY\r\n", actualResponse.getResponseStatusLine());
+        assertEquals("Location: http://127.0.0.1:5000/simple_get\r\n\r\n", actualResponse.getResponseHeaders());
+        assertEquals(requestBodyStub, actualResponse.getResponseBody());
     }
 }

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class RedirectHandlerTest {
 
     @Test

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -26,10 +26,9 @@ class RedirectHandlerTest {
             put("httpMethod", "GET");
             put("requestTarget", "/redirect");
         }};
-        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         RedirectHandler redirectHandler = new RedirectHandler();
 
-        Response actualResponse = redirectHandler.handleResponse(requestMock);
+        Response actualResponse = redirectHandler.handleResponse(new Request(requestLineStub, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 301 MOVED PERMANENTLY\r\n", actualResponse.getResponseStatusLine());
         assertEquals("Location: http://127.0.0.1:5000/simple_get\r\n\r\n", actualResponse.getResponseHeaders());

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -24,9 +24,7 @@ class RedirectHandlerTest {
             put("httpMethod", "GET");
             put("requestTarget", "/redirect");
         }};
-        LinkedHashMap<String, String> requestHeadersStub = new LinkedHashMap<>();
-        String requestBodyStub = "";
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         RedirectHandler redirectHandler = new RedirectHandler();
 
         Response actualResponse = redirectHandler.handleResponse(requestMock);

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -21,7 +21,7 @@ class RedirectHandlerTest {
 
     @Test
     void returnsResponseWithStatusLineAndHeaderOnly() {
-        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
             put("requestTarget", "/redirect");

--- a/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/RedirectHandlerTest.java
@@ -1,0 +1,15 @@
+package org.httpserver.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+class RedirectHandlerTest {
+
+    @Test
+    void returnsGetOnly() {
+        RedirectHandler redirectHandler = new RedirectHandler();
+
+        assertTrue(redirectHandler.allowedHttpMethods().contains("GET"));
+        assertEquals(1, redirectHandler.allowedHttpMethods().size());
+    }
+}

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -32,7 +32,7 @@ class SimpleGetHandlerTest {
     }
 
     @Test
-    void returnsResponseWithResponseStatusLineOnly() {
+    void returnsResponseWithStatusLineOnly() {
         requestLineStub.put("requestTarget", "/simple_get");
         Request requestMock = new Request(requestLineStub, new LinkedHashMap<>(), "");
         SimpleGetHandler simpleGetHandler = new SimpleGetHandler();

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -16,7 +16,7 @@ class SimpleGetHandlerTest {
 
     @BeforeEach
     void setup() {
-        requestLineStub = new LinkedHashMap<String, String>() {{
+        requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
         }};

--- a/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
@@ -9,29 +9,30 @@ import java.util.LinkedHashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class SimpleGetHandlerTest {
+class SimpleGetWithBodyHandlerTest {
+
     @Test
     void returnsGetHeadAndMethodsOnly() {
-        SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
+        SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
-        assertTrue(simpleGetHandler.allowedHttpMethods().contains("GET"));
-        assertTrue(simpleGetHandler.allowedHttpMethods().contains("HEAD"));
-        assertEquals(2, simpleGetHandler.allowedHttpMethods().size());
+        assertTrue(simpleGetWithBodyHandler.allowedHttpMethods().contains("GET"));
+        assertEquals(1, simpleGetWithBodyHandler.allowedHttpMethods().size());
     }
 
     @Test
-    void returnsResponseWithStatusLineOnly() {
+    void returnsResponseWithResponseStatusLineAndBody() {
         LinkedHashMap<String, String> requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
             put("httpMethod", "GET");
-            put("requestTarget", "/simple_get");
+            put("requestTarget", "/simple_get_with_body");
         }};
-        SimpleGetHandler simpleGetHandler = new SimpleGetHandler();
+        SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
-        Response actualResponse = simpleGetHandler.handleResponse(new Request(requestLineStub, new LinkedHashMap<>(), ""));
+        Response actualResponse = simpleGetWithBodyHandler.handleResponse(new Request(requestLineStub, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertTrue(actualResponse.getResponseHeaders().isBlank());
-        assertTrue(actualResponse.getResponseBody().isEmpty());
+        assertEquals("Hello world", actualResponse.getResponseBody());
     }
+
 }

--- a/src/test/java/org/httpserver/request/RequestParserTest.java
+++ b/src/test/java/org/httpserver/request/RequestParserTest.java
@@ -28,8 +28,10 @@ class RequestParserTest {
 
     @Test
     void parseRequestThatHasRequestLineAndHeadersOnly() throws IOException {
-        String mockRequestString = "GET /simple_get HTTP/1.1\n" +
-                "Host: 0.0.0.0:5000\n";
+        String mockRequestString = """
+                GET /simple_get HTTP/1.1
+                Host: 0.0.0.0:5000
+                """;
         ByteArrayInputStream mockInputStream = new ByteArrayInputStream(mockRequestString.getBytes());
         RequestParser requestParser = new RequestParser();
 

--- a/src/test/java/org/httpserver/request/RequestParserTest.java
+++ b/src/test/java/org/httpserver/request/RequestParserTest.java
@@ -12,12 +12,12 @@ class RequestParserTest {
 
     @Test
     void parseRequestThatHasRequestLineOnly() throws IOException {
-        String mockRequestString = "GET /simple_get HTTP/1.1\n" +
-                "\n";
-        ByteArrayInputStream mockInputStream = new ByteArrayInputStream(mockRequestString.getBytes());
-        RequestParser requestParser = new RequestParser();
+        String mockRequestString = """
+                GET /simple_get HTTP/1.1
 
-        Request request = requestParser.parseRequest(mockInputStream);
+                """;
+        Request request = getRequest(mockRequestString);
+
 
         assertEquals("HTTP/1.1", request.getHttpVersion());
         assertEquals("GET", request.getHttpMethod());
@@ -32,10 +32,7 @@ class RequestParserTest {
                 GET /simple_get HTTP/1.1
                 Host: 0.0.0.0:5000
                 """;
-        ByteArrayInputStream mockInputStream = new ByteArrayInputStream(mockRequestString.getBytes());
-        RequestParser requestParser = new RequestParser();
-
-        Request request = requestParser.parseRequest(mockInputStream);
+        Request request = getRequest(mockRequestString);
 
         assertEquals("HTTP/1.1", request.getHttpVersion());
         assertEquals("GET", request.getHttpMethod());
@@ -46,4 +43,10 @@ class RequestParserTest {
         assertNull(request.getRequestBody());
     }
 
+    private Request getRequest(String mockRequestString) throws IOException {
+        ByteArrayInputStream mockInputStream = new ByteArrayInputStream(mockRequestString.getBytes());
+        RequestParser requestParser = new RequestParser();
+
+        return requestParser.parseRequest(mockInputStream);
+    }
 }

--- a/src/test/java/org/httpserver/request/RequestTest.java
+++ b/src/test/java/org/httpserver/request/RequestTest.java
@@ -15,7 +15,7 @@ class RequestTest {
 
     @BeforeEach
     void setup() {
-        LinkedHashMap<String, String> requestLine = new LinkedHashMap<String, String>() {{
+        LinkedHashMap<String, String> requestLine = new LinkedHashMap<>() {{
             put("httpMethod", "GET");
             put("requestTarget", "/simple_get");
             put("httpVersion", "HTTP/1.1");

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -17,7 +17,7 @@ class RouterTest {
 
     @BeforeEach
     void setup() {
-        requestLineStub = new LinkedHashMap<String, String>() {{
+        requestLineStub = new LinkedHashMap<>() {{
             put("httpVersion", "HTTP/1.1");
         }};
         requestHeadersStub = new LinkedHashMap<>();

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -28,10 +28,8 @@ class RouterTest {
     void returnGetHandler_whenGetRoute() {
         requestLineStub.put("httpMethod", "GET");
         requestLineStub.put("requestTarget", "/simple_get");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(SimpleGetHandler.class, actualHandler.getClass());
     }
@@ -40,10 +38,8 @@ class RouterTest {
     void returnGetHandler_whenSimpleGetWithBodyRoute() {
         requestLineStub.put("httpMethod", "GET");
         requestLineStub.put("requestTarget", "/simple_get_with_body");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(SimpleGetHandler.class, actualHandler.getClass());
     }
@@ -52,10 +48,8 @@ class RouterTest {
     void returnHeadHandler_whenHeadRequestRoute() {
         requestLineStub.put("httpMethod", "HEAD");
         requestLineStub.put("requestTarget", "/head_request");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(HeadRequestHandler.class, actualHandler.getClass());
     }
@@ -64,10 +58,8 @@ class RouterTest {
     void returnMethodNotAllowedHandler_whenHttpMethodIncorrect() {
         requestLineStub.put("httpMethod", "GET");
         requestLineStub.put("requestTarget", "/head_request");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(MethodNotAllowedHandler.class, actualHandler.getClass());
     }
@@ -76,21 +68,18 @@ class RouterTest {
     void returnOptionsHandler_whenMethodOptionsRoute() {
         requestLineStub.put("httpMethod", "OPTIONS");
         requestLineStub.put("requestTarget", "/method_options");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(OptionsHandler.class, actualHandler.getClass());
     }
+
     @Test
     void returnOptionsHandlerTwo_whenMethodOptions2Route() {
         requestLineStub.put("httpMethod", "OPTIONS");
         requestLineStub.put("requestTarget", "/method_options2");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(OptionsHandlerTwo.class, actualHandler.getClass());
     }
@@ -99,10 +88,8 @@ class RouterTest {
     void returnPostHandler_whenEchoBodyRoute() {
         requestLineStub.put("httpMethod", "POST");
         requestLineStub.put("requestTarget", "/echo_body");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
         assertEquals(EchoBodyHandler.class, actualHandler.getClass());
     }
@@ -111,25 +98,26 @@ class RouterTest {
     void returnRedirectHandler_whenRedirectRoute() {
         requestLineStub.put("httpMethod", "GET");
         requestLineStub.put("requestTarget", "/redirect");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
 
-        RedirectHandler expectedHandler = new RedirectHandler();
-        Handler actualHandler = router.getHandler(requestMock);
+        Handler actualHandler = getActualHandler();
 
-        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+        assertEquals(RedirectHandler.class, actualHandler.getClass());
     }
 
     @Test
-    void returnPageNotFoundHandler_whenResourceNotAvailable(){
+    void returnPageNotFoundHandler_whenResourceNotAvailable() {
         requestLineStub.put("httpMethod", "GET");
         requestLineStub.put("requestTarget", "/page_not_exist");
+
+        Handler actualHandler = getActualHandler();
+
+        assertEquals(PageNotFoundHandler.class, actualHandler.getClass());
+    }
+
+    private Handler getActualHandler() {
         Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
         Router router = new Router();
 
-        PageNotFoundHandler expectedHandler = new PageNotFoundHandler();
-        Handler actualHandler = router.getHandler(requestMock);
-
-        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+        return router.getHandler(requestMock);
     }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -126,4 +126,17 @@ class RouterTest {
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
+
+    @Test
+    void returnRedirectHandler_whenRedirectRoute() {
+        requestLineStub.put("httpMethod", "GET");
+        requestLineStub.put("requestTarget", "/redirect");
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Router router = new Router();
+
+        RedirectHandler expectedHandler = new RedirectHandler();
+        Handler actualHandler = router.getHandler(requestMock);
+
+        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+    }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -126,17 +126,4 @@ class RouterTest {
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
-
-    @Test
-    void returnRedirectHandler_whenRedirectRoute() {
-        requestLineStub.put("httpMethod", "GET");
-        requestLineStub.put("requestTarget", "/redirect");
-        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
-        Router router = new Router();
-
-        RedirectHandler expectedHandler = new RedirectHandler();
-        Handler actualHandler = router.getHandler(requestMock);
-
-        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
-    }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -41,7 +41,7 @@ class RouterTest {
 
         Handler actualHandler = getActualHandler();
 
-        assertEquals(SimpleGetHandler.class, actualHandler.getClass());
+        assertEquals(SimpleGetWithBodyHandler.class, actualHandler.getClass());
     }
 
     @Test

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -126,4 +126,17 @@ class RouterTest {
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
+
+    @Test
+    void returnPageNotFoundHandler_whenResourceNotAvailable(){
+        requestLineStub.put("httpMethod", "GET");
+        requestLineStub.put("requestTarget", "/page_not_exist");
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Router router = new Router();
+
+        PageNotFoundHandler expectedHandler = new PageNotFoundHandler();
+        Handler actualHandler = router.getHandler(requestMock);
+
+        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+    }
 }

--- a/src/test/java/org/httpserver/server/RouterTest.java
+++ b/src/test/java/org/httpserver/server/RouterTest.java
@@ -113,4 +113,17 @@ class RouterTest {
 
         assertEquals(expectedHandler.getClass(), actualHandler.getClass());
     }
+
+    @Test
+    void returnRedirectHandler_whenRedirectRoute() {
+        requestLineStub.put("httpMethod", "GET");
+        requestLineStub.put("requestTarget", "/redirect");
+        Request requestMock = new Request(requestLineStub, requestHeadersStub, requestBodyStub);
+        Router router = new Router();
+
+        RedirectHandler expectedHandler = new RedirectHandler();
+        Handler actualHandler = router.getHandler(requestMock);
+
+        assertEquals(expectedHandler.getClass(), actualHandler.getClass());
+    }
 }


### PR DESCRIPTION
This PR focuses on `Simple redirect` and 'Page not found` features of acceptance tests
 **Scenario**: Getting a resource that has been moved to a different location
    !  Given I make an GET request to "/redirect"                                                        
    ~  Then my response should have status code 301
    ~  And my response should have a location header with the "http://0.0.0.0:5000/simple_get" URI
    ~  And my response should have an empty body

 **Scenario**: Getting an unconfigured resource returns a 404
    !  Given I make a GET request to a page that does not exist     
    ~  Then my response should have status code 404
    
Changes have been made to `Router`, `RedirectHandler`, `PageNotFoundHandler` and their test classes.
