### PR TITLE
Handle HEAD request to /simple_get_with_body

### DIFF
--- a/src/main/java/org/httpserver/App.java
+++ b/src/main/java/org/httpserver/App.java
@@ -9,6 +9,4 @@ public class App {
         var server = new Server(5000);
         server.start();
     }
-
-
 }

--- a/src/main/java/org/httpserver/handler/EchoBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/EchoBodyHandler.java
@@ -1,12 +1,15 @@
 package org.httpserver.handler;
 
 import org.httpserver.request.Request;
+import org.httpserver.response.ContentType;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
 import org.httpserver.server.HttpMethod;
 
 import java.util.List;
 
+import static org.httpserver.response.ResponseHeaderName.CONTENT_LENGTH;
+import static org.httpserver.response.ResponseHeaderName.CONTENT_TYPE;
 import static org.httpserver.response.StatusCode.OK;
 import static org.httpserver.server.HttpMethod.POST;
 
@@ -19,6 +22,8 @@ public class EchoBodyHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(OK)
+                .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
+                .withHeader(CONTENT_LENGTH, String.valueOf(request.getRequestBody().length()))
                 .withBody(request.getRequestBody())
                 .build();
     }

--- a/src/main/java/org/httpserver/handler/HtmlHandler.java
+++ b/src/main/java/org/httpserver/handler/HtmlHandler.java
@@ -22,8 +22,7 @@ public class HtmlHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(OK)
-                .withHeaderName(CONTENT_TYPE)
-                .withHeaderValue(ContentType.HTML.getValue())
+                .withHeader(CONTENT_TYPE, ContentType.HTML.getValue())
                 .withBody("<html><body><p>HTML Response</p></body></html>")
                 .build();
     }

--- a/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
+++ b/src/main/java/org/httpserver/handler/MethodNotAllowedHandler.java
@@ -1,6 +1,7 @@
 package org.httpserver.handler;
 
 import org.httpserver.request.Request;
+import org.httpserver.response.ContentType;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
 import org.httpserver.server.HttpMethod;
@@ -8,6 +9,7 @@ import org.httpserver.server.HttpMethod;
 import java.util.List;
 
 import static org.httpserver.response.ResponseHeaderName.ALLOW;
+import static org.httpserver.response.ResponseHeaderName.CONTENT_TYPE;
 import static org.httpserver.response.StatusCode.METHOD_NOT_ALLOWED;
 import static org.httpserver.server.HttpMethod.HEAD;
 import static org.httpserver.server.HttpMethod.OPTIONS;
@@ -21,8 +23,7 @@ public class MethodNotAllowedHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(METHOD_NOT_ALLOWED)
-                .withHeaderName(ALLOW)
-                .withHeaderValue(String.format("%s, %s", HEAD, OPTIONS))
+                .withHeader(ALLOW, String.format("%s, %s", HEAD, OPTIONS))
                 .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandler.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandler.java
@@ -20,8 +20,7 @@ public class OptionsHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(OK)
-                .withHeaderName(ALLOW)
-                .withHeaderValue(String.format("%s, %s, %s", GET, HEAD, OPTIONS))
+                .withHeader(ALLOW, String.format("%s, %s, %s", GET, HEAD, OPTIONS))
                 .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
+++ b/src/main/java/org/httpserver/handler/OptionsHandlerTwo.java
@@ -21,8 +21,7 @@ public class OptionsHandlerTwo implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(OK)
-                .withHeaderName(ALLOW)
-                .withHeaderValue(String.format("%s, %s, %s, %s, %s", GET, HEAD, OPTIONS, POST, PUT))
+                .withHeader(ALLOW, String.format("%s, %s, %s, %s, %s", GET, HEAD, OPTIONS, POST, PUT))
                 .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/RedirectHandler.java
+++ b/src/main/java/org/httpserver/handler/RedirectHandler.java
@@ -7,9 +7,10 @@ import org.httpserver.server.HttpMethod;
 
 import java.util.List;
 
+import static org.httpserver.response.ResponseHeaderName.ALLOW;
 import static org.httpserver.response.ResponseHeaderName.LOCATION;
 import static org.httpserver.response.StatusCode.MOVED_PERMANENTLY;
-import static org.httpserver.server.HttpMethod.GET;
+import static org.httpserver.server.HttpMethod.*;
 
 public class RedirectHandler implements Handler {
     public List<HttpMethod> allowedHttpMethods() {
@@ -20,8 +21,7 @@ public class RedirectHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(MOVED_PERMANENTLY)
-                .withHeaderName(LOCATION)
-                .withHeaderValue("http://127.0.0.1:5000/simple_get")
+                .withHeader(LOCATION, "http://127.0.0.1:5000/simple_get")
                 .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -1,22 +1,35 @@
 package org.httpserver.handler;
 
 import org.httpserver.request.Request;
+import org.httpserver.response.ContentType;
 import org.httpserver.response.Response;
 import org.httpserver.response.ResponseBuilder;
+import org.httpserver.response.ResponseHeaderName;
 import org.httpserver.server.HttpMethod;
 
 import java.util.List;
 
+import static org.httpserver.response.ResponseHeaderName.CONTENT_TYPE;
 import static org.httpserver.response.StatusCode.OK;
 import static org.httpserver.server.HttpMethod.GET;
+import static org.httpserver.server.HttpMethod.HEAD;
 
 public class SimpleGetWithBodyHandler implements Handler {
 
     public List<HttpMethod> allowedHttpMethods() {
-        return List.of(GET);
+        return List.of(GET, HEAD);
     }
 
     public Response handleResponse(Request request) {
+        if (request.getHttpMethod() == HEAD) {
+            return new ResponseBuilder()
+                    .withStatusCode(OK)
+                    .withHeaderName(CONTENT_TYPE)
+                    .withHeaderValue(ContentType.TEXT.getValue())
+                    .withHeaderName(ResponseHeaderName.CONTENT_LENGTH)
+                    .withHeaderValue(String.valueOf(request.getRequestBody().length()))
+                    .build();
+        }
         return new ResponseBuilder()
                 .withStatusCode(OK)
                 .withBody("Hello world")

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -9,6 +9,7 @@ import org.httpserver.server.HttpMethod;
 
 import java.util.List;
 
+import static org.httpserver.response.ResponseHeaderName.CONTENT_LENGTH;
 import static org.httpserver.response.ResponseHeaderName.CONTENT_TYPE;
 import static org.httpserver.response.StatusCode.OK;
 import static org.httpserver.server.HttpMethod.GET;
@@ -21,18 +22,21 @@ public class SimpleGetWithBodyHandler implements Handler {
     }
 
     public Response handleResponse(Request request) {
+        String body = "Hello world";
+
         if (request.getHttpMethod() == HEAD) {
             return new ResponseBuilder()
                     .withStatusCode(OK)
-                    .withHeaderName(CONTENT_TYPE)
-                    .withHeaderValue(ContentType.TEXT.getValue())
-                    .withHeaderName(ResponseHeaderName.CONTENT_LENGTH)
-                    .withHeaderValue(String.valueOf(request.getRequestBody().length()))
+                    .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
+                    .withHeader(CONTENT_LENGTH, String.valueOf(body.length()))
                     .build();
         }
+
         return new ResponseBuilder()
                 .withStatusCode(OK)
-                .withBody("Hello world")
+                .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
+                .withHeader(CONTENT_LENGTH, String.valueOf(body.length()))
+                .withBody(body)
                 .build();
     }
 }

--- a/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
+++ b/src/main/java/org/httpserver/handler/SimpleGetWithBodyHandler.java
@@ -24,19 +24,11 @@ public class SimpleGetWithBodyHandler implements Handler {
     public Response handleResponse(Request request) {
         String body = "Hello world";
 
-        if (request.getHttpMethod() == HEAD) {
-            return new ResponseBuilder()
-                    .withStatusCode(OK)
-                    .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
-                    .withHeader(CONTENT_LENGTH, String.valueOf(body.length()))
-                    .build();
-        }
-
-        return new ResponseBuilder()
+        ResponseBuilder responseBuilder =  new ResponseBuilder()
                 .withStatusCode(OK)
                 .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
-                .withHeader(CONTENT_LENGTH, String.valueOf(body.length()))
-                .withBody(body)
-                .build();
+                .withHeader(CONTENT_LENGTH, String.valueOf(body.length()));
+
+        return (request.getHttpMethod() == HEAD) ? responseBuilder.build() : responseBuilder.withBody(body).build();
     }
 }

--- a/src/main/java/org/httpserver/handler/TextHandler.java
+++ b/src/main/java/org/httpserver/handler/TextHandler.java
@@ -20,8 +20,7 @@ public class TextHandler implements Handler {
     public Response handleResponse(Request request) {
         return new ResponseBuilder()
                 .withStatusCode(OK)
-                .withHeaderName(CONTENT_TYPE)
-                .withHeaderValue(ContentType.TEXT.getValue())
+                .withHeader(CONTENT_TYPE, ContentType.TEXT.getValue())
                 .withBody("text response")
                 .build();
     }

--- a/src/main/java/org/httpserver/request/RequestParser.java
+++ b/src/main/java/org/httpserver/request/RequestParser.java
@@ -18,7 +18,9 @@ public class RequestParser {
 
         RequestLine requestLine = getRequestLine(requestLineRead);
         LinkedHashMap<String, String> requestHeadersMap = getRequestHeaders(requestReader);
+        System.out.println("h"+requestHeadersMap);
         String contentLengthHeaderValue = getContentLengthHeaderValue(requestHeadersMap);
+        System.out.println("cv"+contentLengthHeaderValue);
         String requestBody = getRequestMessageBody(contentLengthHeaderValue, requestReader);
 
         return buildRequest(requestLine, requestHeadersMap, requestBody);

--- a/src/main/java/org/httpserver/request/RequestParser.java
+++ b/src/main/java/org/httpserver/request/RequestParser.java
@@ -18,9 +18,7 @@ public class RequestParser {
 
         RequestLine requestLine = getRequestLine(requestLineRead);
         LinkedHashMap<String, String> requestHeadersMap = getRequestHeaders(requestReader);
-        System.out.println("h"+requestHeadersMap);
         String contentLengthHeaderValue = getContentLengthHeaderValue(requestHeadersMap);
-        System.out.println("cv"+contentLengthHeaderValue);
         String requestBody = getRequestMessageBody(contentLengthHeaderValue, requestReader);
 
         return buildRequest(requestLine, requestHeadersMap, requestBody);

--- a/src/main/java/org/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/response/ResponseBuilder.java
@@ -10,17 +10,10 @@ import static org.httpserver.Constant.HTTP_VERSION_NUMBER;
 public class ResponseBuilder {
     private String httpVersion = HTTP_VERSION_NUMBER;
     private StatusCode statusCode;
-    private String headerName = "";
-    private String headerValue = "";
 
     private final HashMap<String, String> headers = new HashMap<>();
     private String body = "";
     private HashMap<String, String> headerMap;
-
-    public ResponseBuilder withHttpVersion(String httpVersion) {
-        this.httpVersion = httpVersion;
-        return this;
-    }
 
     public ResponseBuilder withStatusCode(StatusCode statusCode) {
         this.statusCode = statusCode;
@@ -31,11 +24,6 @@ public class ResponseBuilder {
         headers.put(headerName, headerValue);
         return this;
     }
-
-//    public ResponseBuilder withHeaderValue(String headerValue, String head) {
-//        this.headerValue = headerValue;
-//        return this;
-//    }
 
     public ResponseBuilder withBody(String body) {
         this.body = body;
@@ -53,7 +41,7 @@ public class ResponseBuilder {
     private String handleHeaders() {
         StringBuilder allHeaders = new StringBuilder();
 
-        if (isNoHeader()) {
+        if (headers.isEmpty()) {
             return CRLF;
         }
 
@@ -62,10 +50,6 @@ public class ResponseBuilder {
         }
 
         return allHeaders + CRLF;
-    }
-
-    private boolean isNoHeader() {
-        return headers.isEmpty();
     }
 
     private String handleBody() {

--- a/src/main/java/org/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/response/ResponseBuilder.java
@@ -1,7 +1,7 @@
 package org.httpserver.response;
 
-import org.httpserver.Constant;
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.httpserver.Constant.CRLF;
@@ -12,7 +12,10 @@ public class ResponseBuilder {
     private StatusCode statusCode;
     private String headerName = "";
     private String headerValue = "";
+
+    private final HashMap<String, String> headers = new HashMap<>();
     private String body = "";
+    private HashMap<String, String> headerMap;
 
     public ResponseBuilder withHttpVersion(String httpVersion) {
         this.httpVersion = httpVersion;
@@ -24,15 +27,15 @@ public class ResponseBuilder {
         return this;
     }
 
-    public ResponseBuilder withHeaderName(String headerName) {
-        this.headerName = headerName;
+    public ResponseBuilder withHeader(String headerName, String headerValue) {
+        headers.put(headerName, headerValue);
         return this;
     }
 
-    public ResponseBuilder withHeaderValue(String headerValue) {
-        this.headerValue = headerValue;
-        return this;
-    }
+//    public ResponseBuilder withHeaderValue(String headerValue, String head) {
+//        this.headerValue = headerValue;
+//        return this;
+//    }
 
     public ResponseBuilder withBody(String body) {
         this.body = body;
@@ -48,11 +51,21 @@ public class ResponseBuilder {
     }
 
     private String handleHeaders() {
-        return (isNoHeader() ? "" : headerName + ": " + headerValue + CRLF) + CRLF;
+        StringBuilder allHeaders = new StringBuilder();
+
+        if (isNoHeader()) {
+            return CRLF;
+        }
+
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            allHeaders.append(String.format("%s: %s", header.getKey(), header.getValue())).append(CRLF);
+        }
+
+        return allHeaders + CRLF;
     }
 
     private boolean isNoHeader() {
-        return Objects.equals(headerName, "") && Objects.equals(headerValue, "");
+        return headers.isEmpty();
     }
 
     private String handleBody() {

--- a/src/main/java/org/httpserver/server/Server.java
+++ b/src/main/java/org/httpserver/server/Server.java
@@ -42,7 +42,7 @@ public class Server {
             serverLogger.printHandlerBuildingResponse(handler);
 
             Response response = handler.handleResponse(request);
-            System.out.println("res"+ response.getResponseHeaders());
+
             clientHandler.processSendResponse(response);
             clientHandler.closeClientConnection();
         }

--- a/src/main/java/org/httpserver/server/Server.java
+++ b/src/main/java/org/httpserver/server/Server.java
@@ -42,6 +42,7 @@ public class Server {
             serverLogger.printHandlerBuildingResponse(handler);
 
             Response response = handler.handleResponse(request);
+            System.out.println("res"+ response.getResponseHeaders());
             clientHandler.processSendResponse(response);
             clientHandler.closeClientConnection();
         }

--- a/src/test/java/org/httpserver/handler/EchoBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/EchoBodyHandlerTest.java
@@ -29,7 +29,8 @@ class EchoBodyHandlerTest {
         Response actualResponse = echoBodyHandler.handleResponse(new Request(mockRequestLine, new LinkedHashMap<>(), "some body"));
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        assertTrue(actualResponse.getResponseHeaders().isBlank());
+        assertTrue(actualResponse.getResponseHeaders().contains("Content-Length"));
+        assertTrue(actualResponse.getResponseHeaders().contains("9"));
         assertEquals("some body", actualResponse.getResponseBody());
     }
 }

--- a/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedHashMap;
 
 import static org.httpserver.server.HttpMethod.GET;
+import static org.httpserver.server.HttpMethod.HEAD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,11 +19,12 @@ class SimpleGetWithBodyHandlerTest {
         SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
         assertTrue(simpleGetWithBodyHandler.allowedHttpMethods().contains(GET));
-        assertEquals(1, simpleGetWithBodyHandler.allowedHttpMethods().size());
+        assertTrue(simpleGetWithBodyHandler.allowedHttpMethods().contains(HEAD));
+        assertEquals(2, simpleGetWithBodyHandler.allowedHttpMethods().size());
     }
 
     @Test
-    void returnsResponseWithResponseStatusLineAndBody() {
+    void returnsResponseWith_responseStatusLine_andBody() {
         RequestLine mockRequestLine = new RequestLine(GET, "/simple_get_with_body", "HTTP/1.1");
         SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
@@ -31,6 +33,20 @@ class SimpleGetWithBodyHandlerTest {
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertTrue(actualResponse.getResponseHeaders().isBlank());
         assertEquals("Hello world", actualResponse.getResponseBody());
+    }
+
+    @Test
+    void returnsResponseWith_responseStatusLine_andHeadersOnly() {
+        RequestLine mockRequestLine = new RequestLine(HEAD, "/simple_get_with_body", "HTTP/1.1");
+        SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
+
+        Response actualResponse = simpleGetWithBodyHandler.handleResponse(new Request(mockRequestLine, new LinkedHashMap<>(), ""));
+
+        assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
+        System.out.println("head"+actualResponse.getResponseHeaders());
+        System.out.println("body"+actualResponse.getResponseBody());
+        assertTrue(actualResponse.getResponseHeaders().contains("Content-Length"));
+        assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 
 }

--- a/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
@@ -5,6 +5,7 @@ import org.httpserver.request.RequestLine;
 import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 
 import static org.httpserver.server.HttpMethod.GET;
@@ -24,14 +25,16 @@ class SimpleGetWithBodyHandlerTest {
     }
 
     @Test
-    void returnsResponseWith_responseStatusLine_andBody() {
+    void returnsResponseWith_responseStatusLine_withHeaders_andBody() {
         RequestLine mockRequestLine = new RequestLine(GET, "/simple_get_with_body", "HTTP/1.1");
         SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
         Response actualResponse = simpleGetWithBodyHandler.handleResponse(new Request(mockRequestLine, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        assertTrue(actualResponse.getResponseHeaders().isBlank());
+        System.out.println("header"+ actualResponse.getResponseHeaders());
+        assertTrue(actualResponse.getResponseHeaders().contains("Content-Length"));
+        assertTrue(actualResponse.getResponseHeaders().contains("11"));
         assertEquals("Hello world", actualResponse.getResponseBody());
     }
 
@@ -43,9 +46,8 @@ class SimpleGetWithBodyHandlerTest {
         Response actualResponse = simpleGetWithBodyHandler.handleResponse(new Request(mockRequestLine, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        System.out.println("head"+actualResponse.getResponseHeaders());
-        System.out.println("body"+actualResponse.getResponseBody());
         assertTrue(actualResponse.getResponseHeaders().contains("Content-Length"));
+        assertTrue(actualResponse.getResponseHeaders().contains("11"));
         assertTrue(actualResponse.getResponseBody().isEmpty());
     }
 

--- a/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetWithBodyHandlerTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SimpleGetWithBodyHandlerTest {
 
     @Test
-    void returnsGetMethodOnly() {
+    void returnsGet_andHeadMethodsOnly() {
         SimpleGetWithBodyHandler simpleGetWithBodyHandler = new SimpleGetWithBodyHandler();
 
         assertTrue(simpleGetWithBodyHandler.allowedHttpMethods().contains(GET));
@@ -32,7 +32,6 @@ class SimpleGetWithBodyHandlerTest {
         Response actualResponse = simpleGetWithBodyHandler.handleResponse(new Request(mockRequestLine, new LinkedHashMap<>(), ""));
 
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
-        System.out.println("header"+ actualResponse.getResponseHeaders());
         assertTrue(actualResponse.getResponseHeaders().contains("Content-Length"));
         assertTrue(actualResponse.getResponseHeaders().contains("11"));
         assertEquals("Hello world", actualResponse.getResponseBody());

--- a/src/test/java/org/httpserver/request/RequestParserTest.java
+++ b/src/test/java/org/httpserver/request/RequestParserTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 
 import static org.httpserver.server.HttpMethod.GET;
+import static org.httpserver.server.HttpMethod.POST;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RequestParserTest {
@@ -42,6 +43,25 @@ class RequestParserTest {
             put("Host", "0.0.0.0:5000");
         }}, request.getRequestHeaders());
         assertNull(request.getRequestBody());
+    }
+
+    @Test
+    void parseRequestThatHas_requestLine_headers_andBody() throws IOException {
+        String mockRequestString = """
+                POST /echo_body HTTP/1.1
+                Content-Type: text/plain;charset=utf-8;
+                Content-Length: 9
+                
+                some body
+                """;
+        Request request = getRequest(mockRequestString);
+
+        assertEquals("HTTP/1.1", request.getHttpVersion());
+        assertEquals(POST, request.getHttpMethod());
+        assertEquals("/echo_body", request.getRequestTarget());
+        assertTrue(request.getRequestHeaders().containsKey("Content-Length"));
+        assertTrue(request.getRequestHeaders().containsKey("Content-Type"));
+        assertEquals("some body",request.getRequestBody());
     }
 
     private Request getRequest(String mockRequestString) throws IOException {

--- a/src/test/java/org/httpserver/request/RequestParserTest.java
+++ b/src/test/java/org/httpserver/request/RequestParserTest.java
@@ -51,7 +51,7 @@ class RequestParserTest {
                 POST /echo_body HTTP/1.1
                 Content-Type: text/plain;charset=utf-8;
                 Content-Length: 9
-                
+
                 some body
                 """;
         Request request = getRequest(mockRequestString);
@@ -61,6 +61,7 @@ class RequestParserTest {
         assertEquals("/echo_body", request.getRequestTarget());
         assertTrue(request.getRequestHeaders().containsKey("Content-Length"));
         assertTrue(request.getRequestHeaders().containsKey("Content-Type"));
+        assertEquals("9", request.getRequestHeaders().get("Content-Length"));
         assertEquals("some body",request.getRequestBody());
     }
 


### PR DESCRIPTION
This PR relate to [this ticket](https://trello.com/c/c9kvvzJt/119-simplegetwithbody-make-head-request-at-route) which requires `SimpleGetWithBodyHandler` returns the correct response when `HEAD` request made.

🧪 Codecov coverage: 79%
❓ Gradle test coverage: Class:89% Method:83% Line:81%