### PR TITLE
Bytes refactor

### DIFF
--- a/src/main/java/org/httpserver/client/ClientHandler.java
+++ b/src/main/java/org/httpserver/client/ClientHandler.java
@@ -4,14 +4,16 @@ import org.httpserver.response.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.Socket;
 
 public class ClientHandler {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Socket clientSocket;
     public int clientConnectionCounter;
-    PrintWriter clientResponseWriter;
 
     public ClientHandler(Socket clientSocket) {
         this.clientSocket = clientSocket;
@@ -27,9 +29,7 @@ public class ClientHandler {
         logger.info("Reading client request");
     }
 
-
     public void processSendResponse(Response response) throws IOException {
-        //        clientResponseWriter = createClientResponseWriter();
         byte[] responseStringToBytes = responseStringToBytes(response);
         logger.info("Sending client response");
         sendResponse(responseStringToBytes);
@@ -40,6 +40,7 @@ public class ClientHandler {
         outputStream.write(response.setStatusLineBytes());
         outputStream.write(response.setHeaderBytes());
         outputStream.write(response.setBodyBytes());
+
         return outputStream.toByteArray();
     }
 
@@ -49,14 +50,6 @@ public class ClientHandler {
         clientOutputStream.flush();
         clientOutputStream.close();
     }
-//    private PrintWriter createClientResponseWriter() throws IOException {
-//        return new PrintWriter(clientSocket.getOutputStream(), true);
-//    }
-
-    //    public void sendResponse(Response response, PrintWriter clientResponseWriter) throws IOException {
-//        clientResponseWriter.write(response.responseStringToBytes());
-//        clientResponseWriter.close();
-//    }
 
     public void closeClientConnection() throws IOException {
         clientSocket.close();

--- a/src/main/java/org/httpserver/client/ClientHandler.java
+++ b/src/main/java/org/httpserver/client/ClientHandler.java
@@ -4,9 +4,7 @@ import org.httpserver.response.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.Socket;
 
 public class ClientHandler {
@@ -31,19 +29,34 @@ public class ClientHandler {
 
 
     public void processSendResponse(Response response) throws IOException {
-        clientResponseWriter = createClientResponseWriter();
+        //        clientResponseWriter = createClientResponseWriter();
+        byte[] responseStringToBytes = responseStringToBytes(response);
         logger.info("Sending client response");
-        sendResponse(response, clientResponseWriter);
+        sendResponse(responseStringToBytes);
     }
 
-    private PrintWriter createClientResponseWriter() throws IOException {
-        return new PrintWriter(clientSocket.getOutputStream(), true);
+    public byte[] responseStringToBytes(Response response) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        outputStream.write(response.setStatusLineBytes());
+        outputStream.write(response.setHeaderBytes());
+        outputStream.write(response.setBodyBytes());
+        return outputStream.toByteArray();
     }
 
-    public void sendResponse(Response response, PrintWriter clientResponseWriter) {
-        clientResponseWriter.write(response.stringFormatResponse());
-        clientResponseWriter.close();
+    public void sendResponse(byte[] responseByte) throws IOException {
+        OutputStream clientOutputStream = clientSocket.getOutputStream();
+        clientOutputStream.write(responseByte);
+        clientOutputStream.flush();
+        clientOutputStream.close();
     }
+//    private PrintWriter createClientResponseWriter() throws IOException {
+//        return new PrintWriter(clientSocket.getOutputStream(), true);
+//    }
+
+    //    public void sendResponse(Response response, PrintWriter clientResponseWriter) throws IOException {
+//        clientResponseWriter.write(response.responseStringToBytes());
+//        clientResponseWriter.close();
+//    }
 
     public void closeClientConnection() throws IOException {
         clientSocket.close();

--- a/src/main/java/org/httpserver/client/ClientHandler.java
+++ b/src/main/java/org/httpserver/client/ClientHandler.java
@@ -37,18 +37,21 @@ public class ClientHandler {
 
     public byte[] responseStringToBytes(Response response) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        outputStream.write(response.setStatusLineBytes());
-        outputStream.write(response.setHeaderBytes());
-        outputStream.write(response.setBodyBytes());
+        outputStream.write(response.statusLineBytes());
+        outputStream.write(response.headerBytes());
+        outputStream.write(response.bodyBytes());
 
         return outputStream.toByteArray();
     }
 
     public void sendResponse(byte[] responseByte) throws IOException {
-        OutputStream clientOutputStream = clientSocket.getOutputStream();
-        clientOutputStream.write(responseByte);
-        clientOutputStream.flush();
-        clientOutputStream.close();
+        try (OutputStream clientOutputStream = clientSocket.getOutputStream();) {
+            clientOutputStream.write(responseByte);
+            clientOutputStream.flush();
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+            logger.error("Failed to send response to client");
+        }
     }
 
     public void closeClientConnection() throws IOException {

--- a/src/main/java/org/httpserver/response/Response.java
+++ b/src/main/java/org/httpserver/response/Response.java
@@ -1,10 +1,16 @@
 package org.httpserver.response;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 public class Response {
 
     String responseStatusLine;
     String responseHeaders;
     String responseBody;
+    byte[] statusLineBytes;
+    byte[] headersBytes;
+    byte[] bodyBytes;
 
     public Response(String responseStatusLine, String responseHeaders, String responseBody) {
         this.responseStatusLine = responseStatusLine;
@@ -24,7 +30,34 @@ public class Response {
         return responseBody;
     }
 
+    public byte[] getStatusLineBytes() {
+        return statusLineBytes;
+    }
+
+    public byte[] getHeadersBytes() {
+        return headersBytes;
+    }
+
+    public byte[] getBodyBytes() {
+        return bodyBytes;
+    }
+
     public String stringFormatResponse() {
         return getResponseStatusLine() + getResponseHeaders() + getResponseBody();
+    }
+
+    public byte[] setStatusLineBytes() {
+        statusLineBytes = responseStatusLine.getBytes();
+        return statusLineBytes;
+    }
+
+    public byte[] setHeaderBytes() {
+        headersBytes = responseHeaders.getBytes();
+        return headersBytes;
+    }
+
+    public byte[] setBodyBytes() {
+        bodyBytes = responseBody.getBytes();
+        return bodyBytes;
     }
 }

--- a/src/main/java/org/httpserver/response/Response.java
+++ b/src/main/java/org/httpserver/response/Response.java
@@ -1,8 +1,5 @@
 package org.httpserver.response;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 public class Response {
 
     String responseStatusLine;

--- a/src/main/java/org/httpserver/response/Response.java
+++ b/src/main/java/org/httpserver/response/Response.java
@@ -43,17 +43,17 @@ public class Response {
         return getResponseStatusLine() + getResponseHeaders() + getResponseBody();
     }
 
-    public byte[] setStatusLineBytes() {
+    public byte[] statusLineBytes() {
         statusLineBytes = responseStatusLine.getBytes();
         return statusLineBytes;
     }
 
-    public byte[] setHeaderBytes() {
+    public byte[] headerBytes() {
         headersBytes = responseHeaders.getBytes();
         return headersBytes;
     }
 
-    public byte[] setBodyBytes() {
+    public byte[] bodyBytes() {
         bodyBytes = responseBody.getBytes();
         return bodyBytes;
     }

--- a/src/main/java/org/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/response/ResponseBuilder.java
@@ -1,7 +1,5 @@
 package org.httpserver.response;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -55,31 +53,4 @@ public class ResponseBuilder {
     private String buildBody() {
         return Objects.equals(body, "") ? "" : body;
     }
-
-//    public byte[] responseStringToBytes() throws IOException {
-//        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-//        outputStream.write(getStatusLineBytes());
-//        outputStream.write(getHeaderBytes());
-//        outputStream.write(getBodyBytes());
-//
-//        return outputStream.toByteArray();
-//    }
-//
-//    private byte[] getStatusLineBytes() {
-//
-//        return buildStatusLine().getBytes();
-//    }
-//
-//    private byte[] getHeaderBytes() {
-//        return buildHeaders().getBytes();
-//    }
-//
-//    private byte[] getBodyBytes() {
-//        byte[] bodyBytes = new byte[0];
-//        if (buildBody() != null) {
-//            bodyBytes = buildBody().getBytes();
-//        }
-//        return bodyBytes;
-//    }
-
 }

--- a/src/main/java/org/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/org/httpserver/response/ResponseBuilder.java
@@ -1,5 +1,7 @@
 package org.httpserver.response;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -29,14 +31,14 @@ public class ResponseBuilder {
     }
 
     public Response build() {
-        return new Response(handleStatusLine(), handleHeaders(), handleBody());
+        return new Response(buildStatusLine(), buildHeaders(), buildBody());
     }
 
-    private String handleStatusLine() {
+    private String buildStatusLine() {
         return String.format("%s %s %s", httpVersion, statusCode.getStatusCodeNumber(), statusCode.getStatusCodeName()) + CRLF;
     }
 
-    private String handleHeaders() {
+    private String buildHeaders() {
         StringBuilder allHeaders = new StringBuilder();
 
         if (headers.isEmpty()) {
@@ -50,8 +52,34 @@ public class ResponseBuilder {
         return allHeaders + CRLF;
     }
 
-    private String handleBody() {
+    private String buildBody() {
         return Objects.equals(body, "") ? "" : body;
     }
+
+//    public byte[] responseStringToBytes() throws IOException {
+//        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+//        outputStream.write(getStatusLineBytes());
+//        outputStream.write(getHeaderBytes());
+//        outputStream.write(getBodyBytes());
+//
+//        return outputStream.toByteArray();
+//    }
+//
+//    private byte[] getStatusLineBytes() {
+//
+//        return buildStatusLine().getBytes();
+//    }
+//
+//    private byte[] getHeaderBytes() {
+//        return buildHeaders().getBytes();
+//    }
+//
+//    private byte[] getBodyBytes() {
+//        byte[] bodyBytes = new byte[0];
+//        if (buildBody() != null) {
+//            bodyBytes = buildBody().getBytes();
+//        }
+//        return bodyBytes;
+//    }
 
 }

--- a/src/test/java/org/httpserver/client/ClientHandlerTest.java
+++ b/src/test/java/org/httpserver/client/ClientHandlerTest.java
@@ -4,25 +4,24 @@ import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.net.Socket;
+import java.util.Arrays;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 class ClientHandlerTest {
 
-//    @Test
-//    void sentClientResponseReadCorrectlyAndClosedClientSuccessfully() throws IOException {
-//        Socket mockClientSocket = mock(Socket.class);
-//        ClientHandler clientHandler = new ClientHandler(mockClientSocket);
-//        PrintWriter mockClientResponseWriter = mock(PrintWriter.class);
-//        String mockResponseString = "HTTP/1.1 200 OK";
-//        Response mockResponse = mock(Response.class);
-//        when(mockResponse.stringFormatResponse()).thenReturn(mockResponseString);
-//
-//        clientHandler.sendResponse(mockResponse, mockClientResponseWriter);
-//
-//        verify(mockClientResponseWriter).write("HTTP/1.1 200 OK");
-//        verify(mockClientResponseWriter, times(1)).close();
-//    }
+    @Test
+    void sentClientResponseReadCorrectlyAndConvertedToBytesSuccessfully() throws IOException {
+        Response mockResponse = new Response("HTTP/1.1 200 OK", "", "");
+        Socket mockClientSocket = mock(Socket.class);
+        ClientHandler clientHandler = new ClientHandler(mockClientSocket);
+
+        byte[] actualByte = clientHandler.responseStringToBytes(mockResponse);
+
+        byte[] expectedByte = {72, 84, 84, 80, 47, 49, 46, 49, 32, 50, 48, 48, 32, 79, 75};
+        assertEquals(Arrays.toString(expectedByte), Arrays.toString(expectedByte));
+        assertEquals(expectedByte.length, actualByte.length);
+    }
 }

--- a/src/test/java/org/httpserver/client/ClientHandlerTest.java
+++ b/src/test/java/org/httpserver/client/ClientHandlerTest.java
@@ -11,18 +11,18 @@ import static org.mockito.Mockito.*;
 
 class ClientHandlerTest {
 
-    @Test
-    void sentClientResponseReadCorrectlyAndClosedClientSuccessfully() throws IOException {
-        Socket mockClientSocket = mock(Socket.class);
-        ClientHandler clientHandler = new ClientHandler(mockClientSocket);
-        PrintWriter mockClientResponseWriter = mock(PrintWriter.class);
-        String mockResponseString = "HTTP/1.1 200 OK";
-        Response mockResponse = mock(Response.class);
-        when(mockResponse.stringFormatResponse()).thenReturn(mockResponseString);
-
-        clientHandler.sendResponse(mockResponse, mockClientResponseWriter);
-
-        verify(mockClientResponseWriter).write("HTTP/1.1 200 OK");
-        verify(mockClientResponseWriter, times(1)).close();
-    }
+//    @Test
+//    void sentClientResponseReadCorrectlyAndClosedClientSuccessfully() throws IOException {
+//        Socket mockClientSocket = mock(Socket.class);
+//        ClientHandler clientHandler = new ClientHandler(mockClientSocket);
+//        PrintWriter mockClientResponseWriter = mock(PrintWriter.class);
+//        String mockResponseString = "HTTP/1.1 200 OK";
+//        Response mockResponse = mock(Response.class);
+//        when(mockResponse.stringFormatResponse()).thenReturn(mockResponseString);
+//
+//        clientHandler.sendResponse(mockResponse, mockClientResponseWriter);
+//
+//        verify(mockClientResponseWriter).write("HTTP/1.1 200 OK");
+//        verify(mockClientResponseWriter, times(1)).close();
+//    }
 }

--- a/src/test/java/org/httpserver/client/ClientHandlerTest.java
+++ b/src/test/java/org/httpserver/client/ClientHandlerTest.java
@@ -20,7 +20,7 @@ class ClientHandlerTest {
 
         byte[] actualByte = clientHandler.responseStringToBytes(mockResponse);
 
-        byte[] expectedByte = {72, 84, 84, 80, 47, 49, 46, 49, 32, 50, 48, 48, 32, 79, 75};
+        byte[] expectedByte = "HTTP/1.1 200 OK".getBytes();
         assertEquals(Arrays.toString(expectedByte), Arrays.toString(expectedByte));
         assertEquals(expectedByte.length, actualByte.length);
     }

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -5,6 +5,7 @@ import org.httpserver.request.RequestLine;
 import org.httpserver.response.Response;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 
 import static org.httpserver.server.HttpMethod.GET;
@@ -32,5 +33,7 @@ class SimpleGetHandlerTest {
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertTrue(actualResponse.getResponseHeaders().isBlank());
         assertTrue(actualResponse.getResponseBody().isEmpty());
+        System.out.println("body " + Arrays.toString(actualResponse.getBodyBytes()));
+        System.out.println("body " + actualResponse.getResponseBody());
     }
 }

--- a/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
+++ b/src/test/java/org/httpserver/handler/SimpleGetHandlerTest.java
@@ -33,7 +33,5 @@ class SimpleGetHandlerTest {
         assertEquals("HTTP/1.1 200 OK\r\n", actualResponse.getResponseStatusLine());
         assertTrue(actualResponse.getResponseHeaders().isBlank());
         assertTrue(actualResponse.getResponseBody().isEmpty());
-        System.out.println("body " + Arrays.toString(actualResponse.getBodyBytes()));
-        System.out.println("body " + actualResponse.getResponseBody());
     }
 }


### PR DESCRIPTION
In this pull request I have refactored `ClientHandler,processSendResponse` to send to convert the response string into a bytes and write to `clientSocket.getOutputStream`. I have added byte attributes and setter methods to `Response` class. 

I will now be able to process files in the next PR. As i will be able to convert the file to string and create a Response object as normal and then convert the string to bytes which i will send to the client. 

🧪 Codecov coverage: 80%
❓ Gradle test coverage: Class:93% Method:87% Line:80%